### PR TITLE
Fix a typo in the snapshot documentation

### DIFF
--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -22,7 +22,7 @@ resource "vultr_server" "my_server" {
     os_id = 147
 }
 resource "vultr_snapshot" "my_snapshot" {
-    vps_id       = "${vultr_server.snap.id}"
+    vps_id       = "${vultr_server.my_server.id}"
     description  = "my servers snapshot"
 }
 ```


### PR DESCRIPTION
As the title says. The server name wasn't replaced when this snippet got copied from the test :)