### PR TITLE
Add the ability to set reverse DNS entries for IPv6 addresses

### DIFF
--- a/vultr/data_source_vultr_block_storage.go
+++ b/vultr/data_source_vultr_block_storage.go
@@ -58,7 +58,7 @@ func dataSourceVultrBlockStorageRead(d *schema.ResourceData, meta interface{}) e
 	block, err := client.BlockStorage.List(context.Background())
 
 	if err != nil {
-		return fmt.Errorf("error getting applications: %v", err)
+		return fmt.Errorf("error getting block storages: %v", err)
 	}
 
 	blockList := []govultr.BlockStorage{}

--- a/vultr/data_source_vultr_reverse_ipv6.go
+++ b/vultr/data_source_vultr_reverse_ipv6.go
@@ -1,0 +1,122 @@
+package vultr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vultr/govultr"
+)
+
+func dataSourceVultrReverseIPV6() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVultrReverseIPV6Read,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"reverse": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVultrReverseIPV6Read(d *schema.ResourceData, meta interface{}) error {
+	filters, ok := d.GetOk("filter")
+	if !ok {
+		return errors.New("Error getting filter")
+	}
+
+	var instanceIDs []string
+
+	for _, filter := range filters.(*schema.Set).List() {
+		filterMap := filter.(map[string]interface{})
+
+		name := filterMap["name"]
+		values := filterMap["values"].([]interface{})
+
+		if name == "instance_id" {
+			for _, value := range values {
+				instanceIDs = append(instanceIDs, value.(string))
+			}
+		}
+
+		if name == "ip" {
+			for i, value := range values {
+				ip, err := getCanonicalIPV6(value.(string))
+				if err != nil {
+					return err
+				}
+
+				values[i] = ip
+			}
+		}
+	}
+
+	client := meta.(*Client).govultrClient()
+
+	// If the data source is not being filtered by `instance_id`, consider all
+	// servers
+	if len(instanceIDs) == 0 {
+		servers, err := client.Server.List(context.Background())
+		if err != nil {
+			return fmt.Errorf("Error getting servers: %v", err)
+		}
+
+		for _, server := range servers {
+			// Consider servers with at least one assigned IPv6 subnet
+			if len(server.V6Networks) > 0 {
+				instanceIDs = append(instanceIDs, server.InstanceID)
+			}
+		}
+	}
+
+	filter := buildVultrDataSourceFilter(filters.(*schema.Set))
+
+	var result *govultr.ReverseIPV6
+	resultInstanceID := ""
+
+	for _, instanceID := range instanceIDs {
+		reverseIPV6s, err := client.Server.ListReverseIPV6(context.Background(), instanceID)
+		if err != nil {
+			return fmt.Errorf("Error getting reverse IPv6s: %v", err)
+		}
+
+		for _, reverseIPV6 := range reverseIPV6s {
+			m, err := structToMap(reverseIPV6)
+			if err != nil {
+				return err
+			}
+
+			if filterLoop(filter, m) {
+				if result != nil {
+					return errors.New("Your search returned too many results. " +
+						"Please refine your search to be more specific")
+				}
+
+				result = &reverseIPV6
+				resultInstanceID = instanceID
+			}
+		}
+	}
+
+	if result == nil {
+		return errors.New("No results were found")
+	}
+
+	d.SetId(result.IP)
+	d.Set("instance_id", resultInstanceID)
+	d.Set("ip", result.IP)
+	d.Set("reverse", result.Reverse)
+
+	return nil
+}

--- a/vultr/data_source_vultr_reverse_ipv6.go
+++ b/vultr/data_source_vultr_reverse_ipv6.go
@@ -52,12 +52,7 @@ func dataSourceVultrReverseIPV6Read(d *schema.ResourceData, meta interface{}) er
 
 		if name == "ip" {
 			for i, value := range values {
-				ip, err := getCanonicalIPV6(value.(string))
-				if err != nil {
-					return err
-				}
-
-				values[i] = ip
+				values[i] = value.(string)
 			}
 		}
 	}

--- a/vultr/data_source_vultr_reverse_ipv6.go
+++ b/vultr/data_source_vultr_reverse_ipv6.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/vultr/govultr"
 )
 

--- a/vultr/data_source_vultr_reverse_ipv6_test.go
+++ b/vultr/data_source_vultr_reverse_ipv6_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccDataSourceVultrReverseIPV6_basic(t *testing.T) {

--- a/vultr/data_source_vultr_reverse_ipv6_test.go
+++ b/vultr/data_source_vultr_reverse_ipv6_test.go
@@ -1,0 +1,58 @@
+package vultr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVultrReverseIPV6_basic(t *testing.T) {
+	t.Parallel()
+
+	name := "data.vultr_reverse_ipv6.test"
+
+	rServerLabel := acctest.RandomWithPrefix("tf-vps-reverse-ipv6")
+	reverse := fmt.Sprintf("host-%d.example.com", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVultrReverseIPV6(rServerLabel, reverse),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "instance_id"),
+					resource.TestCheckResourceAttrSet(name, "ip"),
+					resource.TestCheckResourceAttr(name, "reverse", reverse),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVultrReverseIPV6(rServerLabel, reverse string) string {
+	return fmt.Sprintf(`
+		resource "vultr_server" "foo" {
+			plan_id = "201"
+			region_id = "6"
+			os_id = "167"
+			enable_ipv6 = true
+			label = "%s"
+		}
+
+		resource "vultr_reverse_ipv6" "bar" {
+			instance_id = "${vultr_server.foo.id}"
+			ip = "${vultr_server.foo.v6_networks[0].v6_main_ip}"
+			reverse = "%s"
+		}
+
+		data "vultr_reverse_ipv6" "test" {
+			filter {
+				name = "ip"
+				values = ["${vultr_reverse_ipv6.bar.ip}"]
+			}
+		}
+	`, rServerLabel, reverse)
+}

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -43,6 +43,7 @@ func Provider() terraform.ResourceProvider {
 			"vultr_plan":              dataSourceVultrPlan(),
 			"vultr_region":            dataSourceVultrRegion(),
 			"vultr_reserved_ip":       dataSourceVultrReservedIP(),
+			"vultr_reverse_ipv6":      dataSourceVultrReverseIPV6(),
 			"vultr_server":            dataSourceVultrServer(),
 			"vultr_snapshot":          dataSourceVultrSnapshot(),
 			"vultr_ssh_key":           dataSourceVultrSSHKey(),

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -60,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"vultr_iso_private":       resourceVultrIsoPrivate(),
 			"vultr_network":           resourceVultrNetwork(),
 			"vultr_reserved_ip":       resourceVultrReservedIP(),
+			"vultr_reverse_ipv6":      resourceVultrReverseIPV6(),
 			"vultr_snapshot":          resourceVultrSnapshot(),
 			"vultr_snapshot_from_url": resourceVultrSnapshotFromURL(),
 			"vultr_server":            resourceVultrServer(),

--- a/vultr/resource_vultr_reverse_ipv6.go
+++ b/vultr/resource_vultr_reverse_ipv6.go
@@ -41,16 +41,12 @@ func resourceVultrReverseIPV6Create(d *schema.ResourceData, meta interface{}) er
 
 	instanceID := d.Get("instance_id").(string)
 
-	ip, err := getCanonicalIPV6(d.Get("ip").(string))
-	if err != nil {
-		return err
-	}
-
+	ip := d.Get("ip").(string)
+	
 	reverse := d.Get("reverse").(string)
-
 	log.Printf("[INFO] Creating reverse IPv6")
-	err = client.Server.SetReverseIPV6(context.Background(), instanceID, ip, reverse)
-
+	
+	err := client.Server.SetReverseIPV6(context.Background(), instanceID, ip, reverse)
 	if err != nil {
 		return fmt.Errorf("Error creating reverse IPv6: %v", err)
 	}
@@ -103,13 +99,4 @@ func resourceVultrReverseIPV6Delete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return nil
-}
-
-func getCanonicalIPV6(value string) (string, error) {
-	ip := net.ParseIP(value)
-	if ip == nil {
-		return "", fmt.Errorf("Invalid IPv6 address: %s", value)
-	}
-
-	return ip.String(), nil
 }

--- a/vultr/resource_vultr_reverse_ipv6.go
+++ b/vultr/resource_vultr_reverse_ipv6.go
@@ -1,0 +1,115 @@
+package vultr
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vultr/govultr"
+)
+
+func resourceVultrReverseIPV6() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVultrReverseIPV6Create,
+		Read:   resourceVultrReverseIPV6Read,
+		Delete: resourceVultrReverseIPV6Delete,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"reverse": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceVultrReverseIPV6Create(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).govultrClient()
+
+	instanceID := d.Get("instance_id").(string)
+
+	ip, err := getCanonicalIPV6(d.Get("ip").(string))
+	if err != nil {
+		return err
+	}
+
+	reverse := d.Get("reverse").(string)
+
+	log.Printf("[INFO] Creating reverse IPv6")
+	err = client.Server.SetReverseIPV6(context.Background(), instanceID, ip, reverse)
+
+	if err != nil {
+		return fmt.Errorf("Error creating reverse IPv6: %v", err)
+	}
+
+	d.SetId(ip)
+
+	return resourceVultrReverseIPV6Read(d, meta)
+}
+
+func resourceVultrReverseIPV6Read(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).govultrClient()
+
+	instanceID := d.Get("instance_id").(string)
+
+	reverseIPV6s, err := client.Server.ListReverseIPV6(context.Background(), instanceID)
+	if err != nil {
+		return fmt.Errorf("Error getting reverse IPv6s: %v", err)
+	}
+
+	var reverseIPV6 *govultr.ReverseIPV6
+	for i := range reverseIPV6s {
+		if reverseIPV6s[i].IP == d.Id() {
+			reverseIPV6 = &reverseIPV6s[i]
+			break
+		}
+	}
+
+	if reverseIPV6 == nil {
+		log.Printf("[WARN] Removing reverse IPv6 (%s) because it is gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("ip", reverseIPV6.IP)
+	d.Set("reverse", reverseIPV6.Reverse)
+
+	return nil
+}
+
+func resourceVultrReverseIPV6Delete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).govultrClient()
+
+	instanceID := d.Get("instance_id").(string)
+
+	log.Printf("[INFO] Deleting reverse IPv6: %s", d.Id())
+	err := client.Server.DeleteReverseIPV6(context.Background(), instanceID, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("Error destroying reverse IPv6 (%s): %v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func getCanonicalIPV6(value string) (string, error) {
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return "", fmt.Errorf("Invalid IPv6 address: %s", value)
+	}
+
+	return ip.String(), nil
+}

--- a/vultr/resource_vultr_reverse_ipv6.go
+++ b/vultr/resource_vultr_reverse_ipv6.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/vultr/govultr"
 )
 

--- a/vultr/resource_vultr_reverse_ipv6_test.go
+++ b/vultr/resource_vultr_reverse_ipv6_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccVultrReverseIPV6_basic(t *testing.T) {

--- a/vultr/resource_vultr_reverse_ipv6_test.go
+++ b/vultr/resource_vultr_reverse_ipv6_test.go
@@ -1,0 +1,123 @@
+package vultr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccVultrReverseIPV6_basic(t *testing.T) {
+	t.Parallel()
+
+	name := "vultr_reverse_ipv6.test"
+
+	rServerLabel := acctest.RandomWithPrefix("tf-vps-reverse-ipv6")
+	reverse := fmt.Sprintf("host-%d.example.com", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVultrReverseIPV6Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVultrReverseIPV6(rServerLabel, reverse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVultrReverseIPV6Exists(name),
+					resource.TestCheckResourceAttrSet(name, "instance_id"),
+					resource.TestCheckResourceAttrSet(name, "ip"),
+					resource.TestCheckResourceAttr(name, "reverse", reverse),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVultrReverseIPV6Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vultr_reverse_ipv6" {
+			continue
+		}
+
+		exists, err := vultrReverseIPV6Exists(rs)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Reverse IPv6 still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVultrReverseIPV6Exists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Reverse IPv6 not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("Reverse IPv6 ID is not set")
+		}
+
+		exists, err := vultrReverseIPV6Exists(rs)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return fmt.Errorf("Reverse IPv6 does not exist: %s", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccVultrReverseIPV6(rServerLabel, reverse string) string {
+	return fmt.Sprintf(`
+		resource "vultr_server" "foo" {
+			plan_id = "201"
+			region_id = "6"
+			os_id = "167"
+			enable_ipv6 = true
+			label = "%s"
+		}
+
+		resource "vultr_reverse_ipv6" "test" {
+			instance_id = "${vultr_server.foo.id}"
+			ip = "${vultr_server.foo.v6_networks[0].v6_main_ip}"
+			reverse = "%s"
+		}
+	`, rServerLabel, reverse)
+}
+
+func vultrReverseIPV6Exists(rs *terraform.ResourceState) (bool, error) {
+	client := testAccProvider.Meta().(*Client).govultrClient()
+
+	instanceID, ok := rs.Primary.Attributes["instance_id"]
+	if !ok {
+		return false, errors.New("Error getting instance ID")
+	}
+
+	reverseIPV6s, err := client.Server.ListReverseIPV6(context.Background(), instanceID)
+	if err != nil {
+		return false, fmt.Errorf("Error getting reverse IPv6s: %v", err)
+	}
+
+	ip := rs.Primary.ID
+
+	for i := range reverseIPV6s {
+		if reverseIPV6s[i].IP == ip {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/website/docs/d/reverse_ipv6.html.markdown
+++ b/website/docs/d/reverse_ipv6.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "vultr"
+page_title: "Vultr: vultr_reverse_ipv6"
+sidebar_current: "docs-vultr-datasource-reverse-ipv6"
+description: |-
+  Get information about a Vultr Reverse IPv6.
+---
+
+# vultr_reverse_ipv6
+
+Get information about a Vultr Reverse IPv6.
+
+## Example Usage
+
+Get the information for an IPv6 reverse DNS record by `reverse`:
+
+```hcl
+data "vultr_reverse_ipv6" "my_reverse_ipv6" {
+  filter {
+    name = "reverse"
+    values = ["host.example.com"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Required) Query parameters for finding IPv6 reverse DNS records.
+
+The `filter` block supports the following:
+
+* `name` - Attribute name to filter with.
+* `values` - One or more values to filter with.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `instance_id` - The ID of the server the IPv6 reverse DNS record was set for.
+* `ip` - The IPv6 address in canonical format used in the reverse DNS record.
+* `reverse` - The hostname used in the IPv6 reverse DNS record.

--- a/website/docs/r/reverse_ipv6.html.markdown
+++ b/website/docs/r/reverse_ipv6.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "vultr"
+page_title: "Vultr: vultr_reverse_ipv6"
+sidebar_current: "docs-vultr-resource-reverse-ipv6"
+description: |-
+  Provides a Vultr Reverse IPv6 resource. This can be used to create, read, modify, and delete reverse DNS records for IPv6 addresses.
+---
+
+# vultr_reverse_ipv6
+
+Provides a Vultr Reverse IPv6 resource. This can be used to create, read,
+modify, and delete reverse DNS records for IPv6 addresses. Upon success, DNS
+changes may take 6-12 hours to become active.
+
+## Example Usage
+
+Create a new reverse DNS record for an IPv6 address:
+
+```hcl
+resource "vultr_server" "my_server" {
+	plan_id = "201"
+	region_id = "6"
+	os_id = "167"
+	enable_ipv6 = true
+}
+
+resource "vultr_reverse_ipv6" "my_reverse_ipv6" {
+	instance_id = "${vultr_server.my_server.id}"
+	ip = "${vultr_server.my_server.v6_networks[0].v6_main_ip}"
+	reverse = "host.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) The ID of the server you want to set an IPv6
+  reverse DNS record for.
+* `ip` - (Required) The IPv6 address used in the reverse DNS record.
+* `reverse` - (Required) The hostname used in the reverse DNS record.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID is the IPv6 address in canonical format.
+* `instance_id` - The ID of the server you want to set an IPv6 reverse DNS
+  record for.
+* `ip` - The IPv6 address in canonical format used in the reverse DNS record.
+* `reverse` - The hostname used in the reverse DNS record.

--- a/website/docs/r/reverse_ipv6.html.markdown
+++ b/website/docs/r/reverse_ipv6.html.markdown
@@ -38,14 +38,13 @@ The following arguments are supported:
 * `instance_id` - (Required) The ID of the server you want to set an IPv6
   reverse DNS record for.
 * `ip` - (Required) The IPv6 address used in the reverse DNS record.
-* `reverse` - (Required) The hostname used in the reverse DNS record.
+* `reverse` - (Required) The hostname used in the IPv6 reverse DNS record.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID is the IPv6 address in canonical format.
-* `instance_id` - The ID of the server you want to set an IPv6 reverse DNS
-  record for.
+* `instance_id` - The ID of the server the IPv6 reverse DNS record was set for.
 * `ip` - The IPv6 address in canonical format used in the reverse DNS record.
-* `reverse` - The hostname used in the reverse DNS record.
+* `reverse` - The hostname used in the IPv6 reverse DNS record.

--- a/website/vultr.erb
+++ b/website/vultr.erb
@@ -61,6 +61,9 @@
             <li<%= sidebar_current("docs-vultr-datasource-reserved-ip") %>>
               <a href="/docs/providers/vultr/d/reserved_ip.html">vultr_reserved_ip</a>
             </li> 
+            <li<%= sidebar_current("docs-vultr-datasource-reverse-ipv6") %>>
+              <a href="/docs/providers/vultr/d/reverse_ipv6.html">vultr_reverse_ipv6</a>
+            </li>
             <li<%= sidebar_current("docs-vultr-datasource-server") %>>
               <a href="/docs/providers/vultr/d/server.html">vultr_server</a>
             </li>      

--- a/website/vultr.erb
+++ b/website/vultr.erb
@@ -109,6 +109,9 @@
             <li<%= sidebar_current("docs-vultr-resource-reserved-ip") %>>
               <a href="/docs/providers/vultr/r/reserved_ip.html">vultr_reserved_ip</a>
             </li>
+            <li<%= sidebar_current("docs-vultr-resource-reverse-ipv6") %>>
+              <a href="/docs/providers/vultr/r/reverse_ipv6.html">vultr_reverse_ipv6</a>
+            </li>
             <li<%= sidebar_current("docs-vultr-resource-server") %>>
               <a href="/docs/providers/vultr/r/server.html">vultr_server</a>
             </li>


### PR DESCRIPTION
Hello,

This PR implements the IPv6 side of #18. `resourceVultrReverseIPV6` doesn't implement `Update` yet: I couldn't find a proper way to handle differences between non-canonical IPv6 addresses specified in Terraform configuration files, and canonical IPv6 addresses returned by the Vultr API.

Here is what's left to do:
- [x] Implement a data source
- [x] Create data source acceptance tests
- [x] Write data source documentation
- [x] Implement a resource
- [x] Create resource acceptance tests
- [x] Write resource documentation