### PR TITLE
optional reservedip param for server resource

### DIFF
--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -130,6 +130,11 @@ func resourceVultrServer() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"reserved_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
 			"firewall_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -261,6 +266,7 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 		Tag:                  d.Get("tag").(string),
 		FirewallGroupID:      d.Get("firewall_group_id").(string),
 		ScriptID:             d.Get("script_id").(string),
+		ReservedIPV4:         d.Get("reserved_ip").(string),
 	}
 
 	var os int

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `hostname` - (Optional) The hostname to assign to the server.
 * `tag` - (Optional) The tag to assign to the server.
 * `label` - (Optional) A label for the server.
+* `reserved_ip` - (Optional) IP address of the floating IP to use as the main IP of this server.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This adds in the optional param of `reserved_ip` to be passed in for server create.

This param will takes in a reserved ip address, previously created, and during server creation it will use that reserved-ip as its main ip

Closes #24 