### PR TITLE
Resource/Reserved-ip : attached-id optional

### DIFF
--- a/vultr/resource_vultr_reserved_ip.go
+++ b/vultr/resource_vultr_reserved_ip.go
@@ -38,6 +38,7 @@ func resourceVultrReservedIP() *schema.Resource {
 			},
 			"attached_id": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 			"subnet": {

--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -132,6 +132,7 @@ func resourceVultrServer() *schema.Resource {
 			},
 			"reserved_ip": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Computed: true,
 				Optional: true,
 			},


### PR DESCRIPTION
Adding in a optional param to the `attached-id` field 