### PR TITLE
BlockStorage live attach/detach flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
 	github.com/pkg/errors v0.9.1
-	github.com/vultr/govultr v0.3.1
+	github.com/vultr/govultr v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vultr/govultr v0.3.1 h1:r0JPvWUSGmRAHEhevtpJS+j+7DdK+m8xyvGkZlIc2XA=
 github.com/vultr/govultr v0.3.1/go.mod h1:81RwK1wAmb08alkFDJiZmu9gdv+IO+UamzaF0+PIieE=
+github.com/vultr/govultr v0.3.2 h1:1tV/88jkm+4Y345qAXBe3peNbnmvCY/VAIZApklbKkI=
+github.com/vultr/govultr v0.3.2/go.mod h1:81RwK1wAmb08alkFDJiZmu9gdv+IO+UamzaF0+PIieE=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vendor/github.com/vultr/govultr/CHANGELOG.md
+++ b/vendor/github.com/vultr/govultr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v0.3.2](https://github.com/vultr/govultr/compare/v0.3.1..v0.3.2) (2020-03-25)
+### Enhancement
+*  Added support to live attach/detach blockstorage [#55](https://github.com/vultr/govultr/pull/55)
+
 ## [v0.3.1](https://github.com/vultr/govultr/compare/v0.3.0..v0.3.1) (2020-03-11)
 ### Enhancement
 *  Added support for Load Balancers SSL Calls [#53](https://github.com/vultr/govultr/pull/53)

--- a/vendor/github.com/vultr/govultr/block_storage.go
+++ b/vendor/github.com/vultr/govultr/block_storage.go
@@ -12,10 +12,10 @@ import (
 // BlockStorageService is the interface to interact with Block-Storage endpoint on the Vultr API
 // Link: https://www.vultr.com/api/#block
 type BlockStorageService interface {
-	Attach(ctx context.Context, blockID, InstanceID string) error
+	Attach(ctx context.Context, blockID, InstanceID, liveAttach string) error
 	Create(ctx context.Context, regionID, size int, label string) (*BlockStorage, error)
 	Delete(ctx context.Context, blockID string) error
-	Detach(ctx context.Context, blockID string) error
+	Detach(ctx context.Context, blockID, liveDetach string) error
 	SetLabel(ctx context.Context, blockID, label string) error
 	List(ctx context.Context) ([]BlockStorage, error)
 	Get(ctx context.Context, blockID string) (*BlockStorage, error)
@@ -119,13 +119,18 @@ func (b *BlockStorage) unmarshalStr(value string) (string, error) {
 }
 
 // Attach will link a given block storage to a given Vultr vps
-func (b *BlockStorageServiceHandler) Attach(ctx context.Context, blockID, InstanceID string) error {
+// If liveAttach is set to "yes" the block storage will be attached without reloading the instance
+func (b *BlockStorageServiceHandler) Attach(ctx context.Context, blockID, InstanceID, liveAttach string) error {
 
 	uri := "/v1/block/attach"
 
 	values := url.Values{
 		"SUBID":           {blockID},
 		"attach_to_SUBID": {InstanceID},
+	}
+
+	if liveAttach == "yes" {
+		values.Add("live", "yes")
 	}
 
 	req, err := b.client.NewRequest(ctx, http.MethodPost, uri, values)
@@ -200,12 +205,17 @@ func (b *BlockStorageServiceHandler) Delete(ctx context.Context, blockID string)
 }
 
 // Detach will de-link a given block storage to the Vultr vps it is attached to
-func (b *BlockStorageServiceHandler) Detach(ctx context.Context, blockID string) error {
+// If liveDetach is set to "yes" the block storage will be detached without reloading the instance
+func (b *BlockStorageServiceHandler) Detach(ctx context.Context, blockID, liveDetach string) error {
 
 	uri := "/v1/block/detach"
 
 	values := url.Values{
 		"SUBID": {blockID},
+	}
+
+	if liveDetach == "yes" {
+		values.Add("live", "yes")
 	}
 
 	req, err := b.client.NewRequest(ctx, http.MethodPost, uri, values)

--- a/vendor/github.com/vultr/govultr/govultr.go
+++ b/vendor/github.com/vultr/govultr/govultr.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	version     = "0.3.1"
+	version     = "0.3.2"
 	defaultBase = "https://api.vultr.com"
 	userAgent   = "govultr/" + version
 	rateLimit   = 600 * time.Millisecond

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vultr/govultr v0.3.1
+# github.com/vultr/govultr v0.3.2
 github.com/vultr/govultr
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty

--- a/vultr/resource_vultr_block_storage.go
+++ b/vultr/resource_vultr_block_storage.go
@@ -127,8 +127,6 @@ func resourceVultrBlockStorageRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).govultrClient()
-
-	d.Partial(true)
 	live := d.Get("live").(string)
 
 	if d.HasChange("label") {
@@ -148,7 +146,6 @@ func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error resizing block storage (%s): %v", d.Id(), err)
 		}
-		d.SetPartial("size_gb")
 	}
 
 	if d.HasChange("attached_id") {
@@ -174,10 +171,7 @@ func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) e
 				return fmt.Errorf("Error attaching block storage (%s): %v", d.Id(), err)
 			}
 		}
-		d.SetPartial("attached_id")
 	}
-
-	d.Partial(false)
 
 	return resourceVultrBlockStorageRead(d, meta)
 }

--- a/vultr/resource_vultr_block_storage.go
+++ b/vultr/resource_vultr_block_storage.go
@@ -49,6 +49,10 @@ func resourceVultrBlockStorage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"live": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -66,6 +70,12 @@ func resourceVultrBlockStorageCreate(d *schema.ResourceData, meta interface{}) e
 		label = l.(string)
 	}
 
+	var live string
+	li, ok := d.GetOk("live")
+	if ok {
+		live = li.(string)
+	}
+
 	bs, err := client.BlockStorage.Create(context.Background(), regionID, size, label)
 	if err != nil {
 		return fmt.Errorf("Error creating block storage: %v", err)
@@ -77,7 +87,7 @@ func resourceVultrBlockStorageCreate(d *schema.ResourceData, meta interface{}) e
 	if instanceID != "" {
 		log.Printf("[INFO] Attaching block storage (%s)", d.Id())
 		time.Sleep(5 * time.Second)
-		err := client.BlockStorage.Attach(context.Background(), d.Id(), instanceID)
+		err := client.BlockStorage.Attach(context.Background(), d.Id(), instanceID, live)
 		if err != nil {
 			return fmt.Errorf("Error attaching block storage (%s): %v", d.Id(), err)
 		}
@@ -96,6 +106,14 @@ func resourceVultrBlockStorageRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error getting block storage: %v", err)
 	}
 
+	var live string
+	li, ok := d.GetOk("live")
+	if ok {
+		live = li.(string)
+	}
+
+	d.Set("live", live)
+
 	d.Set("date_created", bs.DateCreated)
 	d.Set("cost_per_month", bs.CostPerMonth)
 	d.Set("status", bs.Status)
@@ -111,6 +129,7 @@ func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*Client).govultrClient()
 
 	d.Partial(true)
+	live := d.Get("live").(string)
 
 	if d.HasChange("label") {
 		log.Printf(`[INFO] Updating block storage label (%s)`, d.Id())
@@ -142,7 +161,7 @@ func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 			if bs.InstanceID != "" {
 				log.Printf(`[INFO] Detaching block storage (%s)`, d.Id())
-				err := client.BlockStorage.Detach(context.Background(), d.Id())
+				err := client.BlockStorage.Detach(context.Background(), d.Id(), live)
 				if err != nil {
 					return fmt.Errorf("Error detaching block storage (%s): %v", d.Id(), err)
 				}
@@ -150,7 +169,7 @@ func resourceVultrBlockStorageUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 		if newVal.(string) != "" {
 			log.Printf(`[INFO] Attaching block storage (%s)`, d.Id())
-			err := client.BlockStorage.Attach(context.Background(), d.Id(), newVal.(string))
+			err := client.BlockStorage.Attach(context.Background(), d.Id(), newVal.(string), live)
 			if err != nil {
 				return fmt.Errorf("Error attaching block storage (%s): %v", d.Id(), err)
 			}
@@ -167,10 +186,11 @@ func resourceVultrBlockStorageDelete(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*Client).govultrClient()
 
 	instanceID := d.Get("attached_id").(string)
+	live := d.Get("live").(string)
 
 	if instanceID != "" {
 		log.Printf("[INFO] Detaching block storage (%s)", d.Id())
-		err := client.BlockStorage.Detach(context.Background(), d.Id())
+		err := client.BlockStorage.Detach(context.Background(), d.Id(), live)
 		if err != nil {
 			return fmt.Errorf("Error detaching block storage (%s): %v", d.Id(), err)
 		}

--- a/website/docs/r/block_storage.html.markdown
+++ b/website/docs/r/block_storage.html.markdown
@@ -29,6 +29,8 @@ The following arguments are supported:
 * `region_id` - (Required) Region in which this block storage will reside in. (Currently only NJ/NY supported region_id 1)
 * `attached_id` - (Optional) VPS ID that you want to have this block storage attached to.
 * `label` - (Optional) Label that is given to your block storage.
+* `live` - (Optional) Live will allow attachment of the volume to an instance without a restart. Values are `yes` or `no` default is `no`.
+
 
 
 ## Attributes Reference
@@ -43,6 +45,7 @@ The following attributes are exported:
 * `date_created` - The date this block storage was created.
 * `status` - Current status of your block storage.
 * `id` - The ID for this block storage.
+* `live` - Flag which will determine of a volume should be attached with a restart or not.
 
 ## Import
 


### PR DESCRIPTION
Adding support for live attaching/detaching of block storage flag. 

This will allow you to attach block storage volumes to instances without having the instances to restart.