### PR TITLE
Detach ISO on instance delete

### DIFF
--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -614,6 +614,14 @@ func resourceVultrServerDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	isoID, ok := d.GetOk("os_id")
+	if ok {
+		err = client.Server.IsoDetach(context.Background(), d.Id())
+		if err != nil {
+			return fmt.Errorf("error detaching iso (%s) from instance (%s) : %v", d.Id(), isoID, err)
+		}
+	}
+
 	err = client.Server.Delete(context.Background(), d.Id())
 
 	if err != nil {


### PR DESCRIPTION
When you delete an instance with an ISO attached the ISO gets detached during the deletion process. However this deletion process may take a few seconds which is causing issues with deleting the ISO since it still may be in a attached state.

To solve this if there is a `iso_id` set then prior to deletion we should detach the iso.



Relates to #33 