### PR TITLE
Custom import for DNS Records

### DIFF
--- a/vultr/resource_vultr_dns_records_test.go
+++ b/vultr/resource_vultr_dns_records_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -32,6 +33,37 @@ func TestAccVultrDnsRecord_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "type", "A"),
 					resource.TestCheckResourceAttr(name, "ttl", "3600"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccVultrDnsRecord_importBasic(t *testing.T) {
+	resourceName := "vultr_dns_record.example"
+	rString := acctest.RandString(6) + ".com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVultrDnsDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVultrDnsRecord_import(rString),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Requires passing both the ID and domain
+				ImportStateIdPrefix: fmt.Sprintf("%s,", rString),
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   false,
+				ImportStateIdPrefix: fmt.Sprintf("%s,", "nonexistent.com"),
+				ExpectError:         regexp.MustCompile(`error getting DNS records for DNS Domain nonexistent.com: Invalid domain.  Check domain value and ensure your API key matches the domains's account`),
 			},
 		},
 	})
@@ -79,4 +111,21 @@ func testAccVultrDnsRecord_base(name string) string {
   			type = "A"
   			ttl = "3600"
 		}`, name)
+}
+
+func testAccVultrDnsRecord_import(domainName string) string {
+	time.Sleep(1 * time.Second)
+	return fmt.Sprintf(`
+		resource "vultr_dns_domain" "my-site" {
+  			domain = "%s"
+  			server_ip = "10.0.0.0"
+		}
+
+		resource "vultr_dns_record" "example" {
+  			data = "10.0.0.1"
+  			domain = "${vultr_dns_domain.my-site.id}"
+  			name = "terra"
+  			type = "A"
+  			ttl = "3600"
+		}`, domainName)
 }

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -51,3 +51,11 @@ The following attributes are exported:
 * `type` - Type of record.
 * `priority` - Priority of this record (only required for MX and SRV). 
 * `ttl` -  The time to live of this record.
+
+## Import
+
+DNS Records can be imported using the Dns Domain `domain` and DNS Record `ID` e.g.
+
+```
+terraform import vultr_dns_record.rec domain.com,123
+```


### PR DESCRIPTION
This will allow you to import existing records into your TF state. 

Command to do so is 
`terraform import vultr_dns_record.rec DOMAIN,RECORDID`

Thanks to @SamWhited who got the bulk of this done in #12 

Closes #6 