### PR TITLE
V1 : Fix user-data for strings to be encoded on create/update call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
 	github.com/pkg/errors v0.9.1
-	github.com/vultr/govultr v0.5.0
+	github.com/vultr/govultr v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vultr/govultr v0.5.0 h1:iQzYhzbokmpDARbvIkvTkoyS7WMH82zVTKAL1PZ4JOA=
-github.com/vultr/govultr v0.5.0/go.mod h1:wZZXZbYbqyY1n3AldoeYNZK4Wnmmoq6dNFkvd5TV3ss=
+github.com/vultr/govultr v1.0.0 h1:yeJrYp9wyA4xXaQZ7eOL2u1wKn2JU79HjRevwvpxbJ4=
+github.com/vultr/govultr v1.0.0/go.mod h1:wZZXZbYbqyY1n3AldoeYNZK4Wnmmoq6dNFkvd5TV3ss=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vendor/github.com/vultr/govultr/CHANGELOG.md
+++ b/vendor/github.com/vultr/govultr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.0.0](https://github.com/vultr/govultr/compare/v0.5.0..v1.0.0) (2020-09-03)
+### Feature
+*  Promoting GoVultr to v1.0.0. Moving forward all v1 changes will be made against the [v1](https://github.com/vultr/govultr/tree/v1) branch.
+
 ## [v0.5.0](https://github.com/vultr/govultr/compare/v0.4.2..v0.5.0) (2020-08-25)
 ### Enhancement
 *  Servers: Enable/Disable DDOS Protection [#75](https://github.com/vultr/govultr/pull/75)

--- a/vendor/github.com/vultr/govultr/govultr.go
+++ b/vendor/github.com/vultr/govultr/govultr.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	version     = "0.5.0"
+	version     = "1.0.0"
 	defaultBase = "https://api.vultr.com"
 	userAgent   = "govultr/" + version
 	rateLimit   = 600 * time.Millisecond

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,7 +225,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vultr/govultr v0.5.0
+# github.com/vultr/govultr v1.0.0
 github.com/vultr/govultr
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty

--- a/vultr/data_source_vultr_server_ipv4.go
+++ b/vultr/data_source_vultr_server_ipv4.go
@@ -23,7 +23,7 @@ func dataSourceVultrServerIPV4() *schema.Resource {
 				Computed: true,
 			},
 			"reverse": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -2,6 +2,7 @@ package vultr
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"strconv"
@@ -259,7 +260,7 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 		EnablePrivateNetwork: d.Get("enable_private_network").(bool),
 		Label:                d.Get("label").(string),
 		AutoBackups:          d.Get("auto_backup").(bool),
-		UserData:             d.Get("user_data").(string),
+		UserData:             base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string))),
 		NotifyActivate:       d.Get("notify_activate").(bool),
 		DDOSProtection:       d.Get("ddos_protection").(bool),
 		Hostname:             d.Get("hostname").(string),
@@ -527,7 +528,7 @@ func resourceVultrServerUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("user_data") {
 		log.Printf("[INFO] Updating user_data")
-		if err := client.Server.SetUserData(context.Background(), d.Id(), d.Get("user_data").(string)); err != nil {
+		if err := client.Server.SetUserData(context.Background(), d.Id(), base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string)))); err != nil {
 			return fmt.Errorf("error occured while updating user_data for server %s : %v", d.Id(), err)
 		}
 	}

--- a/vultr/resource_vultr_server_ipv4.go
+++ b/vultr/resource_vultr_server_ipv4.go
@@ -26,7 +26,7 @@ func resourceVultrServerIPV4() *schema.Resource {
 				Computed: true,
 			},
 			"reverse": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"reboot": {


### PR DESCRIPTION


## Description
Resolves breaking change where user-data is required to be b64 encoded. Terraform will handle the encoding and continue to accept strings 

Also updated govultr to v1.0.0 this doesn't have any breaking changes or impact.

## Related Issues
closes #64 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
