### PR TITLE
go: fix old github paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-vultr
+module github.com/vultr/terraform-provider-vultr
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-vultr/vultr"
+	"github.com/vultr/terraform-provider-vultr/vultr"
 )
 
 func main() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


## Description
<!-- Write a brief description of the changes introduced by this PR -->
Go files still point to old repository which is already archived. This PR fixes paths to the current repo. 

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Without updated paths, both automatic and manual builds on NixOS fail.
https://github.com/NixOS/nixpkgs/pull/98760

```
nix-build -A terraform-providers.vultr
these derivations will be built:
  /nix/store/8sfs2knxs6k5q40r2a0740mq4xahd3r5-terraform-provider-vultr-1.4.1.drv
building '/nix/store/8sfs2knxs6k5q40r2a0740mq4xahd3r5-terraform-provider-vultr-1.4.1.drv'...
unpacking sources
unpacking source archive /nix/store/a4kgcw5iizr6f7qx9025229x82v5vkgx-source
source root is source
patching sources
configuring
building
go/src/github.com/vultr/terraform-provider-vultr/main.go:5:2: cannot find package "github.com/terraform-providers/terraform-provider-vultr/vultr" in any of:
        /build/go/src/github.com/vultr/terraform-provider-vultr/vendor/github.com/terraform-providers/terraform-provider-vultr/vultr (vendor tree)
        /nix/store/bqdbizzgdcckkci0splpnhgy1c13h2z0-go-1.15.3/share/go/src/github.com/terraform-providers/terraform-provider-vultr/vultr (from $GOROOT)
        /build/go/src/github.com/terraform-providers/terraform-provider-vultr/vultr (from $GOPATH)
builder for '/nix/store/8sfs2knxs6k5q40r2a0740mq4xahd3r5-terraform-provider-vultr-1.4.1.drv' failed with exit code 1
error: build of '/nix/store/8sfs2knxs6k5q40r2a0740mq4xahd3r5-terraform-provider-vultr-1.4.1.drv' failed
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

I've successfully built and tested (`make test`, not full `testacc`) the package with these changes.