### PR TITLE
bumping govultr + userdata b64 changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
 	github.com/pkg/errors v0.9.1
-	github.com/vultr/govultr v1.0.0
+	github.com/vultr/govultr v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vultr/govultr v1.0.0 h1:yeJrYp9wyA4xXaQZ7eOL2u1wKn2JU79HjRevwvpxbJ4=
-github.com/vultr/govultr v1.0.0/go.mod h1:wZZXZbYbqyY1n3AldoeYNZK4Wnmmoq6dNFkvd5TV3ss=
+github.com/vultr/govultr v1.1.1 h1:ntltxMYyJstjKz1v2CLNxFZiqjlt/8HqD1GZeJ/fAMc=
+github.com/vultr/govultr v1.1.1/go.mod h1:QXCNTRg0nwu95ayiMC3feYvrAFTLnj94s2FiibIpoC4=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -108,6 +108,7 @@ func resourceVultrServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
+				ForceNew: true,
 			},
 			"notify_activate": {
 				Type:     schema.TypeBool,
@@ -524,13 +525,6 @@ func resourceVultrServerUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error while waiting for Server %s to be in a active state : %s", d.Id(), err)
 		}
 
-	}
-
-	if d.HasChange("user_data") {
-		log.Printf("[INFO] Updating user_data")
-		if err := client.Server.SetUserData(context.Background(), d.Id(), base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string)))); err != nil {
-			return fmt.Errorf("error occured while updating user_data for server %s : %v", d.Id(), err)
-		}
 	}
 
 	if d.HasChange("firewall_group_id") {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
There have been some changes to API v1 that relate to how it consumes user-data. User-data now has to be base64 encoded. 

Also changing user-data will result in a `ForceNew` on that resource. 
## Related Issues
Fixes #69 
Fixes #68 
### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
