### PR TITLE
remove validation on reservered ip for instances

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/vultr/govultr/v2"
@@ -126,11 +124,10 @@ func resourceVultrInstance() *schema.Resource {
 				Optional: true,
 			},
 			"reserved_ip": {
-				Type:         schema.TypeString,
-				ForceNew:     true, // force new?
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: validation.IsIPv4Address,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Computed: true,
+				Optional: true,
 			},
 			"firewall_group_id": {
 				Type:     schema.TypeString,

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -123,7 +123,7 @@ func resourceVultrInstance() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
-			"reserved_ip": {
+			"reserved_ip_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Computed: true,
@@ -244,7 +244,7 @@ func resourceVultrInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		Tag:                  d.Get("tag").(string),
 		FirewallGroupID:      d.Get("firewall_group_id").(string),
 		ScriptID:             d.Get("script_id").(string),
-		ReservedIPv4:         d.Get("reserved_ip").(string),
+		ReservedIPv4:         d.Get("reserved_ip_id").(string),
 		Region:               d.Get("region").(string),
 		Plan:                 d.Get("plan").(string),
 	}

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `hostname` - (Optional) The hostname to assign to the server.
 * `tag` - (Optional) The tag to assign to the server.
 * `label` - (Optional) A label for the server.
-* `reserved_ip` - (Optional) IP address of the floating IP to use as the main IP of this server.
+* `reserved_ip` - (Optional) ID of the floating IP to use as the main IP of this server.
 
 ## Attributes Reference
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `hostname` - (Optional) The hostname to assign to the server.
 * `tag` - (Optional) The tag to assign to the server.
 * `label` - (Optional) A label for the server.
-* `reserved_ip` - (Optional) ID of the floating IP to use as the main IP of this server.
+* `reserved_ip_id` - (Optional) ID of the floating IP to use as the main IP of this server.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description
Instances require the ID instead of the IP for reserved_ips. Currently there is a validation that will not allow the passing of IDs.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
