### PR TITLE
Removal of ForceNew on emails

### DIFF
--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -78,7 +78,6 @@ func resourceVultrBareMetalServer() *schema.Resource {
 			"activation_email": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 				Default:  true,
 			},
 			"hostname": {

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -104,7 +104,6 @@ func resourceVultrInstance() *schema.Resource {
 			},
 			"activation_email": {
 				Type:     schema.TypeBool,
-				ForceNew: true,
 				Optional: true,
 				Default:  true,
 			},


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
The `ForceNew` on activation email causes issues on imports as it is a new field and it will want to trigger a rebuild.

There is no need to have a forced rebuild for emails.

## Related Issues
Fixes #82 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
