### PR TITLE
Fix typo in firewall protocol validation

### DIFF
--- a/vultr/resource_vultr_firewall_rule.go
+++ b/vultr/resource_vultr_firewall_rule.go
@@ -36,7 +36,7 @@ func resourceVultrFirewallRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"tcmp", "tcp", "udp", "gre", "ah", "esp"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"icmp", "tcp", "udp", "gre", "ah", "esp"}, false),
 			},
 			"subnet": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Fixes the protocol validation in firewall rules so users can create icmp firewall rules

## Related Issues
Fixes an issue I found.
```
root@acme:/terraform/jdmulloy-vultr-terraform/firewall # terraform plan

Error: expected protocol to be one of [tcmp tcp udp gre ah esp], got icmp

  on firewall.tf line 125, in resource "vultr_firewall_rule" "ipv4_icmp":
 125: resource "vultr_firewall_rule" "ipv4_icmp" {



Error: expected protocol to be one of [tcmp tcp udp gre ah esp], got icmp

  on firewall.tf line 184, in resource "vultr_firewall_rule" "ipv6_icmp":
 184: resource "vultr_firewall_rule" "ipv6_icmp" {
```

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
