### PR TITLE
feat: delete ISO even if already attached

### DIFF
--- a/vultr/resource_vultr_iso_private.go
+++ b/vultr/resource_vultr_iso_private.go
@@ -129,9 +129,9 @@ func resourceVultrIsoDelete(ctx context.Context, d *schema.ResourceData, meta in
 			return diag.Errorf("error deleting ISO %s : failed to parse IP to which ISO is attached: %s", d.Id(), ip)
 		}
 
+		// default is 100 instances
+		var options govultr.ListOptions
 		for {
-			// default is 100 instances
-			var options govultr.ListOptions
 			instances, meta, err := client.Instance.List(ctx, &options)
 			if err != nil {
 				return diag.Errorf("error deleting ISO %s : failed to list instances for detaching ISO", d.Id(), err)
@@ -151,13 +151,13 @@ func resourceVultrIsoDelete(ctx context.Context, d *schema.ResourceData, meta in
 						return diag.Errorf("error deleting ISO %s: failed to delete ISO: %s", d.Id(), err)
 					}
 				}
-				options.Cursor = meta.Links.Next
 			}
 
 			// no more instances to check
-			if options.Cursor == "" {
+			if meta.Links.Next == "" {
 				break
 			}
+			options.Cursor = meta.Links.Next
 		}
 		return diag.Errorf("failed to identify instance associated with IP %s for deleting ISO %s", ip, d.Id())
 	}

--- a/vultr/resource_vultr_iso_private.go
+++ b/vultr/resource_vultr_iso_private.go
@@ -132,7 +132,7 @@ func resourceVultrIsoDelete(ctx context.Context, d *schema.ResourceData, meta in
 		// default is 100 instances
 		var options govultr.ListOptions
 		for {
-			instances, meta, err := client.Instance.List(ctx, &options)
+			instances, responseMeta, err := client.Instance.List(ctx, &options)
 			if err != nil {
 				return diag.Errorf("error deleting ISO %s : failed to list instances for detaching ISO", d.Id(), err)
 			}
@@ -150,14 +150,15 @@ func resourceVultrIsoDelete(ctx context.Context, d *schema.ResourceData, meta in
 					if err = client.ISO.Delete(ctx, d.Id()); err != nil {
 						return diag.Errorf("error deleting ISO %s: failed to delete ISO: %s", d.Id(), err)
 					}
+					return nil
 				}
 			}
 
 			// no more instances to check
-			if meta.Links.Next == "" {
+			if responseMeta.Links.Next == "" {
 				break
 			}
-			options.Cursor = meta.Links.Next
+			options.Cursor = responseMeta.Links.Next
 		}
 		return diag.Errorf("failed to identify instance associated with IP %s for deleting ISO %s", ip, d.Id())
 	}

--- a/vultr/resource_vultr_iso_private.go
+++ b/vultr/resource_vultr_iso_private.go
@@ -2,8 +2,10 @@ package vultr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"time"
 
@@ -72,7 +74,7 @@ func resourceVultrIsoCreate(ctx context.Context, d *schema.ResourceData, meta in
 	_, err = waitForIsoAvailable(ctx, d, "complete", []string{"pending"}, "status", meta)
 	if err != nil {
 		return diag.Errorf(
-			"error while waiting for ISO %s to be completed: %s", d.Id(), err)
+			"error while waiting for ISO %s detach to be completed: %s", d.Id(), err)
 	}
 
 	return resourceVultrIsoRead(ctx, d, meta)
@@ -107,7 +109,71 @@ func resourceVultrIsoDelete(ctx context.Context, d *schema.ResourceData, meta in
 	log.Printf("[INFO] Deleting iso : %s", d.Id())
 
 	if err := client.ISO.Delete(ctx, d.Id()); err != nil {
-		return diag.Errorf("error destroying ISO %s : %v", d.Id(), err)
+		// decode the error
+		var attachedErr struct {
+			Error  string `json:"error"`
+			Status int    `json:"status"`
+		}
+
+		errR := strings.NewReader(err.Error())
+		jsonErr := json.NewDecoder(errR).Decode(&attachedErr)
+		if jsonErr != nil {
+			return diag.Errorf("error destroying ISO %s : %v: %v", d.Id(), err, jsonErr)
+		}
+
+		if !strings.Contains(attachedErr.Error, "is still attached to") {
+			return diag.Errorf("error destroying ISO %s : %v: %v", d.Id(), err)
+		}
+
+		parts := strings.Split(attachedErr.Error, " ")
+		ip := parts[len(parts)-1]
+		if parsedIP := net.ParseIP(ip); parsedIP == nil {
+			return diag.Errorf("error destroying ISO %s : failed to parse IP to which ISO is attached", d.Id())
+		}
+
+		m := govultr.ListOptions{
+			PerPage: 50,
+		}
+		insts, imeta, err := client.Instance.List(ctx, &m)
+		if err != nil {
+			return diag.Errorf("error destroying ISO %s : failed to list instances for detaching ISO", d.Id(), err)
+		}
+
+		// check for the instance with this IP, return on failure or discovery
+		for _, instance := range insts {
+			if instance.MainIP == ip {
+				if err := client.Instance.DetachISO(ctx, instance.ID); err != nil {
+					return diag.Errorf("error destroying ISO %s : failed to detach from instances %s : %s", d.Id(), instance.ID, err)
+				}
+				_, err := waitForIsoDetached(ctx, instance.ID, "ready", []string{"isomounted"}, "status", meta)
+				if err != nil {
+					return diag.Errorf("error while waiting for ISO %s to detach from instance %s: %s", d.Id(), instance.ID, err)
+				}
+				return resourceVultrIsoDelete(ctx, d, meta) // warning: possible infinite recursion
+			}
+		}
+
+		// in case it wasn't in the first batch
+		for imeta.Links.Next != "" {
+			m.Cursor = imeta.Links.Next
+			insts, _, err = client.Instance.List(ctx, &m)
+			if err != nil {
+				return diag.Errorf("error destroying ISO %s : failed to obtain list of instances using cursor %s", d.Id(), m.Cursor)
+			}
+
+			for _, instance := range insts {
+				if instance.MainIP == ip {
+					if err := client.Instance.DetachISO(ctx, instance.ID); err != nil {
+						return diag.Errorf("error destroying ISO %s : failed to detach from instances %s : %s", d.Id(), instance.ID, err)
+					}
+					_, err := waitForIsoDetached(ctx, instance.ID, "ready", []string{"isomounted"}, "status", meta)
+					if err != nil {
+						return diag.Errorf("error while waiting for ISO %s to detach from instance %s: %s", d.Id(), instance.ID, err)
+					}
+					return resourceVultrIsoDelete(ctx, d, meta) // warning: possible infinite recursion
+				}
+			}
+		}
 	}
 
 	return nil
@@ -146,5 +212,36 @@ func newIsoStateRefresh(ctx context.Context,
 
 		log.Printf("[INFO] The ISO Status is %s", iso.Status)
 		return &iso, iso.Status, nil
+	}
+}
+
+func waitForIsoDetached(ctx context.Context, instanceID string, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
+	log.Printf(
+		"[INFO] Waiting for ISO to detach from %s",
+		instanceID, attribute)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:        pending,
+		Target:         []string{target},
+		Refresh:        isoDetachStateRefresh(ctx, instanceID, meta, attribute),
+		Timeout:        60 * time.Minute,
+		Delay:          10 * time.Second,
+		MinTimeout:     3 * time.Second,
+		NotFoundChecks: 60,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func isoDetachStateRefresh(ctx context.Context, instanceID string, meta interface{}, attr string) resource.StateRefreshFunc {
+	client := meta.(*Client).govultrClient()
+	return func() (interface{}, string, error) {
+
+		log.Printf("[INFO] Detaching ISO")
+		iso, err := client.Instance.ISOStatus(ctx, instanceID)
+		if err != nil {
+			return nil, "", fmt.Errorf("error getting ISO status for instance %s : %s", instanceID, err)
+		}
+		return &iso, iso.State, nil
 	}
 }

--- a/vultr/resource_vultr_iso_private.go
+++ b/vultr/resource_vultr_iso_private.go
@@ -218,7 +218,7 @@ func newIsoStateRefresh(ctx context.Context,
 func waitForIsoDetached(ctx context.Context, instanceID string, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
 	log.Printf(
 		"[INFO] Waiting for ISO to detach from %s",
-		instanceID, attribute)
+		instanceID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:        pending,


### PR DESCRIPTION
## Description

It's currently impossible to change the URL of an ISO resource that's attached to an instance. This PR allows for the deletion of an ISO that's attached to an instance at deletion-time.

### Code/Logical Structure

1. Try do delete the ISO
2. If deletion errors, then we check to see if the error message contains information about attachment to an instance (only the IP address, the error message doesn't contain an instance ID)
3. If we detect an IP address of an instance then we try to associated the IP address with the instance ID
4. If we determine the instance ID then we try to detach the ISO from the instance (waiting until completion)
5. If detachment is successful, then we recursively call `resourceVultrIsoDelete` to attempt to delete again.

## Related Issues
#128

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally? **Yes, but I have written no unit tests. I tested a few times against my `terraform` infrastructure.**
