### PR TITLE
Update example usage

### DIFF
--- a/website/docs/r/object_storage.html.markdown
+++ b/website/docs/r/object_storage.html.markdown
@@ -16,7 +16,7 @@ Create a new object storage subscription.
 
 ```hcl
 resource "vultr_object_storage" "tf" {
-    object_storage_cluster_id = 2
+    cluster_id = 2
     label = "tf-label"
 }
 ```


### PR DESCRIPTION
Correct example usage:
```
resource "vultr_object_storage" "tf" {
    object_storage_cluster_id = 2
    label = "tf-label"
}
```
The argument object_storage_cluster_id need to be changed to `cluster_id `.