### PR TITLE
Resource BareMetal importer fix

### DIFF
--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -61,7 +61,6 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Default:  false,
 			},
 			"ssh_key_ids": {
 				Type:     schema.TypeList,
@@ -79,7 +78,6 @@ func resourceVultrBareMetalServer() *schema.Resource {
 			"activation_email": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"hostname": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
We had default values set on `enable_ipv6` and `activation_email` which are only used during creation. So when you would import it would complain that the default value doesn't match up to what is returned on the get/read `null`

## Related Issues
#156 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
