### PR TITLE
Fix broken links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,23 +85,23 @@ Dependency:
 
 ## 1.5.0 (November 09, 2020)
 Breaking Change:
-- resource/vultr_server: Changing `user_data` will now trigger a `force_new` [70](https://github.com/terraform-providers/terraform-provider-vultr/pull/70)
+- resource/vultr_server: Changing `user_data` will now trigger a `force_new` [70](https://github.com/vultr/terraform-provider-vultr/pull/70)
 
 Dependency:
-- updated GoVultr to v1.1.1 [70](https://github.com/terraform-providers/terraform-provider-vultr/pull/70)
+- updated GoVultr to v1.1.1 [70](https://github.com/vultr/terraform-provider-vultr/pull/70)
 
 ## 1.4.1 (September 15, 2020)
 BUG FIXES:
-- resource/vultr_server: Fix bug that did not allow user-data to be passed in as a string [65](https://github.com/terraform-providers/terraform-provider-vultr/pull/65)
+- resource/vultr_server: Fix bug that did not allow user-data to be passed in as a string [65](https://github.com/vultr/terraform-provider-vultr/pull/65)
 
 ## 1.4.0 (August 28, 2020)
 FEATURES:
-- New Resource : vultr_server_ipv4 [61](https://github.com/terraform-providers/terraform-provider-vultr/pull/61)
-- New Resource : vultr_reverse_ipv4 [61](https://github.com/terraform-providers/terraform-provider-vultr/pull/61)
-- New Resource : vultr_reverse_ipv6 [20](https://github.com/terraform-providers/terraform-provider-vultr/pull/20)
-- New Data Source : vultr_server_ipv4 [61](https://github.com/terraform-providers/terraform-provider-vultr/pull/61)
-- New Data Source : vultr_reverse_ipv4 [61](https://github.com/terraform-providers/terraform-provider-vultr/pull/61)
-- New Data Source : vultr_reverse_ipv6 [20](https://github.com/terraform-providers/terraform-provider-vultr/pull/20)
+- New Resource : vultr_server_ipv4 [61](https://github.com/vultr/terraform-provider-vultr/pull/61)
+- New Resource : vultr_reverse_ipv4 [61](https://github.com/vultr/terraform-provider-vultr/pull/61)
+- New Resource : vultr_reverse_ipv6 [20](https://github.com/vultr/terraform-provider-vultr/pull/20)
+- New Data Source : vultr_server_ipv4 [61](https://github.com/vultr/terraform-provider-vultr/pull/61)
+- New Data Source : vultr_reverse_ipv4 [61](https://github.com/vultr/terraform-provider-vultr/pull/61)
+- New Data Source : vultr_reverse_ipv6 [20](https://github.com/vultr/terraform-provider-vultr/pull/20)
 
 IMPROVEMENTS:
 - resource/vultr_server: Ability to enable/disable DDOS post create [59](https://github.com/vultr/terraform-provider-vultr/pull/59)
@@ -109,59 +109,59 @@ IMPROVEMENTS:
 
 ## 1.3.2 (June 17, 2020)
 IMPROVEMENTS:
-- resource/vultr_dns_record: New custom importer allows you to import DNS Records [51](https://github.com/terraform-providers/terraform-provider-vultr/pull/51)
-- resource/vultr_firewall_rule: New custom importer allows you to import Firewall Rules [52](https://github.com/terraform-providers/terraform-provider-vultr/pull/52)
+- resource/vultr_dns_record: New custom importer allows you to import DNS Records [51](https://github.com/vultr/terraform-provider-vultr/pull/51)
+- resource/vultr_firewall_rule: New custom importer allows you to import Firewall Rules [52](https://github.com/vultr/terraform-provider-vultr/pull/52)
 
 ## 1.3.1 (June 11, 2020)
 IMPROVEMENTS:
-- resource/vultr_dns_domain: Making `server_ip` optional. If `server_ip` is not supplied terraform will now create the DNS resource with no records. [48](https://github.com/terraform-providers/terraform-provider-vultr/pull/48)
+- resource/vultr_dns_domain: Making `server_ip` optional. If `server_ip` is not supplied terraform will now create the DNS resource with no records. [48](https://github.com/vultr/terraform-provider-vultr/pull/48)
 
 ## 1.3.0 (June 03, 2020)
 BUG FIXES:
-- resource/vultr_dns_record: Able to create record with `priority` of `0` [45](https://github.com/terraform-providers/terraform-provider-vultr/pull/45)
+- resource/vultr_dns_record: Able to create record with `priority` of `0` [45](https://github.com/vultr/terraform-provider-vultr/pull/45)
 
 FEATURES:
-- New Resource : vultr_object_storage [41](https://github.com/terraform-providers/terraform-provider-vultr/pull/41)
-- New Data Source : vultr_object_storage [41](https://github.com/terraform-providers/terraform-provider-vultr/pull/41)
+- New Resource : vultr_object_storage [41](https://github.com/vultr/terraform-provider-vultr/pull/41)
+- New Data Source : vultr_object_storage [41](https://github.com/vultr/terraform-provider-vultr/pull/41)
 
 ## 1.2.0 (May 27, 2020)
 BUG FIXES:
-- Typo in `website/docs/index.html.markdown` [38](https://github.com/terraform-providers/terraform-provider-vultr/pull/38)
+- Typo in `website/docs/index.html.markdown` [38](https://github.com/vultr/terraform-provider-vultr/pull/38)
 
 FEATURES:
-- New Resource : vultr_load_balancer [37](https://github.com/terraform-providers/terraform-provider-vultr/pull/37)
-- New Data Source : vultr_load_balancer [37](https://github.com/terraform-providers/terraform-provider-vultr/pull/37)
+- New Resource : vultr_load_balancer [37](https://github.com/vultr/terraform-provider-vultr/pull/37)
+- New Data Source : vultr_load_balancer [37](https://github.com/vultr/terraform-provider-vultr/pull/37)
 
 ## 1.1.5 (April 07, 2020)
 BUG FIXES:
-- resource/vultr_server: Detach ISO prior to deletion if instance was created with ISO. [34](https://github.com/terraform-providers/terraform-provider-vultr/issues/34)
+- resource/vultr_server: Detach ISO prior to deletion if instance was created with ISO. [34](https://github.com/vultr/terraform-provider-vultr/issues/34)
 
 ## 1.1.4 (March 30, 2020)
 IMPROVEMENTS:
-- resource/block_storage: Adding new optional param `live` to allow attaching/detaching of block storage to instances without restarts [31](https://github.com/terraform-providers/terraform-provider-vultr/pull/31)
+- resource/block_storage: Adding new optional param `live` to allow attaching/detaching of block storage to instances without restarts [31](https://github.com/vultr/terraform-provider-vultr/pull/31)
 
 ## 1.1.3 (March 24, 2020)
 BUG FIXES:
-- resource/reserved_ip: Adding `computed: true` to `attached_id` to prevent issues when Vultr assigns this [29](https://github.com/terraform-providers/terraform-provider-vultr/pull/29)
-- resource/vultr_server: Adding `ForceNew: true` to `reserved_ip` to prevent any issues where the main floating ip may get deleted and cause issues with the instance [29](https://github.com/terraform-providers/terraform-provider-vultr/pull/29/files)
+- resource/reserved_ip: Adding `computed: true` to `attached_id` to prevent issues when Vultr assigns this [29](https://github.com/vultr/terraform-provider-vultr/pull/29)
+- resource/vultr_server: Adding `ForceNew: true` to `reserved_ip` to prevent any issues where the main floating ip may get deleted and cause issues with the instance [29](https://github.com/vultr/terraform-provider-vultr/pull/29/files)
 
 ## 1.1.2 (March 19, 2020)
 IMPROVEMENTS:
-- resource/vultr_server: New optional field `reserved_ip` which lets you assign a `reserved_ip` during server creation [#26](https://github.com/terraform-providers/terraform-provider-vultr/pull/26).
-- resource/reserved_ip: During deletion any instances that are attached to the reserved_ip are detached [#27](https://github.com/terraform-providers/terraform-provider-vultr/pull/27).
-- Migrated to Terraform Plugin SDK [#21](https://github.com/terraform-providers/terraform-provider-vultr/issues/21)
-- docs/snapshot fixed typo in snapshot [#19](https://github.com/terraform-providers/terraform-provider-vultr/pull/19)
+- resource/vultr_server: New optional field `reserved_ip` which lets you assign a `reserved_ip` during server creation [#26](https://github.com/vultr/terraform-provider-vultr/pull/26).
+- resource/reserved_ip: During deletion any instances that are attached to the reserved_ip are detached [#27](https://github.com/vultr/terraform-provider-vultr/pull/27).
+- Migrated to Terraform Plugin SDK [#21](https://github.com/vultr/terraform-provider-vultr/issues/21)
+- docs/snapshot fixed typo in snapshot [#19](https://github.com/vultr/terraform-provider-vultr/pull/19)
 
 ## 1.1.1 (December 02, 2019)
 IMPROVEMENTS:
-- resource/vultr_block_storage: Attaches block storage on creation. Also reattaches block storage to instances if you taint the instance.[#9](https://github.com/terraform-providers/terraform-provider-vultr/pull/9) Thanks @oogy!
+- resource/vultr_block_storage: Attaches block storage on creation. Also reattaches block storage to instances if you taint the instance.[#9](https://github.com/vultr/terraform-provider-vultr/pull/9) Thanks @oogy!
 
 ## 1.1.0 (November 22, 2019)
 IMPROVEMENTS:
--   provider: Retry mechanism configuration `retry_limit` was added to allow adjusting how many retries should be attempted. [#7](https://github.com/terraform-providers/terraform-provider-vultr/pull/7).
+-   provider: Retry mechanism configuration `retry_limit` was added to allow adjusting how many retries should be attempted. [#7](https://github.com/vultr/terraform-provider-vultr/pull/7).
 
 BUG FIXES:
-- Fixed go module name [#4](https://github.com/terraform-providers/terraform-provider-vultr/pull/4)
+- Fixed go module name [#4](https://github.com/vultr/terraform-provider-vultr/pull/4)
 
 ## 1.0.5 (October 24, 2019)
 


### PR DESCRIPTION
## Description
Since `terraform-proivders/terraform-provider-vultr` moved to `vultr/terraform-provider-vultr`, the links in CHANGELOG, referenced `terraform-providers/terraform-provider-vultr`, became broken.

This pull request fixes the issue by making the links reference `vultr/terraform-provider-vultr`.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
