### PR TITLE
Docs : resource/vultr_kubernetes note kubeconfigs are b64 encoded

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -75,8 +75,9 @@ func resourceVultrKubernetes() *schema.Resource {
 				Computed: true,
 			},
 			"kube_config": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Base64 encoded KubeConfig",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 		},
 	}

--- a/website/docs/r/kubernetes.html.markdown
+++ b/website/docs/r/kubernetes.html.markdown
@@ -60,7 +60,7 @@ The following attributes are exported:
 * `endpoint` - Domain for your Kubernetes clusters control plane.
 * `ip` - IP address of VKE cluster control plane.
 * `date_created` - Date of VKE cluster creation.
-* `kube_config` - Kubeconfig for this VKE cluster.
+* `kube_config` - Base64 encoded Kubeconfig for this VKE cluster.
 * `node_pools` - Contains the default node pool that was deployed.
 
 `node_pools`


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Add missing descriptions + docs that the `kube_config` field is b64 endoed

## Related Issues
fixes #168 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
