### PR TITLE
Adjusted default TF timeout for Bare Metal

### DIFF
--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -165,6 +165,11 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
## Description
Current context timeout for BM is 20 minutes. These instances can generally take longer than this to provision. Bumped this to 60 minutes

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
