### PR TITLE
instance read had invalid error message check

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -366,7 +366,7 @@ func resourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 
 	instance, err := client.Instance.Get(ctx, d.Id())
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "invalid server") {
+		if strings.Contains(err.Error(), "invalid instance ID") {
 			log.Printf("[WARN] Removing instance (%s) because it is gone", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Instance read has a check where it sees if the instance no longer exists. If it doesn't then nil out the instance ID in TF state.

It was still error checking against API v1 error messages which was preventing TF from redeploying a deleted instance.

## Related Issues
#177 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
