### PR TITLE
Bump govultr to v2.12.0, adjust monthly charges to float

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/vultr/govultr/v2 v2.11.0
+	github.com/vultr/govultr/v2 v2.12.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/go.sum
+++ b/go.sum
@@ -302,10 +302,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vultr/govultr/v2 v2.9.2 h1:Hq3LVrlNjtbkIadxos0gQuMZ35ytvTpbBeEuT/CUPBk=
-github.com/vultr/govultr/v2 v2.9.2/go.mod h1:JjUljQdSZx+MELCAJvZ/JH32bJotmflnsyS0NOjb8Jg=
-github.com/vultr/govultr/v2 v2.11.0 h1:cvxH1mC/VTs2oRx3njhIhpypg2EBE70rlxAKKtRU/Zg=
-github.com/vultr/govultr/v2 v2.11.0/go.mod h1:JjUljQdSZx+MELCAJvZ/JH32bJotmflnsyS0NOjb8Jg=
+github.com/vultr/govultr/v2 v2.12.0 h1:sTVEsTN+nvS0SINdbtlmBAQALRcJgLzfYfshj14IaCw=
+github.com/vultr/govultr/v2 v2.12.0/go.mod h1:JjUljQdSZx+MELCAJvZ/JH32bJotmflnsyS0NOjb8Jg=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/github.com/vultr/govultr/v2/CHANGELOG.md
+++ b/vendor/github.com/vultr/govultr/v2/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## GoVultr v1 changelog is located [here](https://github.com/vultr/govultr/blob/v1/CHANGELOG.md)
 
+## [v2.12.0](https://github.com/vultr/govultr/compare/v2.11.1..v2.12.0) (2021-12-01)
+### Breaking Changes
+* Plans : Changed `MonthlyCost` from `int` to `float32` [192](https://github.com/vultr/govultr/pull/192)
+
+## [v2.11.1](https://github.com/vultr/govultr/compare/v2.11.0..v2.11.1) (2021-11-26)
+### Bug fixes
+* LoadBalancers : Fixed SSL struct json params to the proper API fields [189](https://github.com/vultr/govultr/pull/189)
+
 ## [v2.11.0](https://github.com/vultr/govultr/compare/v2.10.0..v2.11.0) (2021-11-18)
 ### Breaking Changes
 * Instances : Update call will now return `*Instance` in addition to `error` [185](https://github.com/vultr/govultr/pull/185)

--- a/vendor/github.com/vultr/govultr/v2/govultr.go
+++ b/vendor/github.com/vultr/govultr/v2/govultr.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	version     = "2.11.0"
+	version     = "2.12.0"
 	defaultBase = "https://api.vultr.com"
 	userAgent   = "govultr/" + version
 	rateLimit   = 500 * time.Millisecond

--- a/vendor/github.com/vultr/govultr/v2/load_balancer.go
+++ b/vendor/github.com/vultr/govultr/v2/load_balancer.go
@@ -118,8 +118,8 @@ type LBFirewallRule struct {
 
 // SSL represents valid SSL config
 type SSL struct {
-	PrivateKey  string `json:"ssl_private_key,omitempty"`
-	Certificate string `json:"ssl_certificate,omitempty"`
+	PrivateKey  string `json:"private_key,omitempty"`
+	Certificate string `json:"certificate,omitempty"`
 	Chain       string `json:"chain,omitempty"`
 }
 

--- a/vendor/github.com/vultr/govultr/v2/plans.go
+++ b/vendor/github.com/vultr/govultr/v2/plans.go
@@ -29,7 +29,7 @@ type BareMetalPlan struct {
 	Disk        int      `json:"disk"`
 	DiskCount   int      `json:"disk_count"`
 	Bandwidth   int      `json:"bandwidth"`
-	MonthlyCost int      `json:"monthly_cost"`
+	MonthlyCost float32  `json:"monthly_cost"`
 	Type        string   `json:"type"`
 	Locations   []string `json:"locations"`
 }
@@ -42,7 +42,7 @@ type Plan struct {
 	Disk        int      `json:"disk"`
 	DiskCount   int      `json:"disk_count"`
 	Bandwidth   int      `json:"bandwidth"`
-	MonthlyCost int      `json:"monthly_cost"`
+	MonthlyCost float32  `json:"monthly_cost"`
 	Type        string   `json:"type"`
 	Locations   []string `json:"locations"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vultr/govultr/v2 v2.11.0
+# github.com/vultr/govultr/v2 v2.12.0
 ## explicit
 github.com/vultr/govultr/v2
 # github.com/zclconf/go-cty v1.8.4

--- a/vultr/data_source_vultr_plan.go
+++ b/vultr/data_source_vultr_plan.go
@@ -31,7 +31,7 @@ func dataSourceVultrPlan() *schema.Resource {
 				Computed: true,
 			},
 			"monthly_cost": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeFloat,
 				Computed: true,
 			},
 			"type": {


### PR DESCRIPTION
## Description
This PR bumps govultr to the newest release of v2.12.0. In addition, it also changes the type for monthly charges from int to float.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
