### PR TITLE
Implement data source filtering on string lists.

### DIFF
--- a/vultr/data_source_vultr_common_schema.go
+++ b/vultr/data_source_vultr_common_schema.go
@@ -68,13 +68,33 @@ func filterLoop(f []filter, m map[string]interface{}) bool {
 	return true
 }
 
-func valuesLoop(values []string, i interface{}) bool {
-	for _, v := range values {
-		if v == i {
-			return true
+func valuesLoop(values []string, actual interface{}) bool {
+	switch actual.(type) {
+	case []interface{}:
+		// It's an array of strings, so something like: location
+		var found bool
+		for _, i := range values {
+			found = false
+			for _, j := range actual.([]interface{}) {
+				if i == j {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
 		}
+		return true
+	default:
+		// It's a string, so something like: ram, type, vcpu_count
+		for _, i := range values {
+			if actual == i {
+				return true
+			}
+		}
+		return false
 	}
-	return false
 }
 
 func dataSourceFiltersSchema() *schema.Schema {


### PR DESCRIPTION
## Description

Previously, attempting to filter a data source on string lists (like the locations field) would silently fail. This change implements filtering on such fields by expanding `valuesLoop`. It's probably possible to make things a bit simpler by reworking `structToMap` (and possibly more) if someone were to feel so inclined.

For example, it is now possible to do:

```tf
data "vultr_region" "server_region" {
  filter {
    name   = "city"
    values = ["Tokyo"]
  }
  filter {
    name   = "country"
    values = ["JP"]
  }
}

data "vultr_plan" "server_plan" {
  filter {
    name   = "type"
    values = ["vc2"]
  }
  filter {
    name   = "vcpu_count"
    values = [2]
  }
  filter {
    name   = "ram"
    values = [4096]
  }
  filter {
    name   = "locations"
    values = [data.vultr_region.server_region.id]
  }
}
```

...and the result would be, correctly, a single plan which depends on the existence of that plan at the Tokyo, Japan location. This makes it possible to depend on the existence of a specific plan, at a specific location, and a failure to find that plan will result in an earlier failure than if we had attempted to blindly create the resource. This also restores the ability to find resources without having to depend on directly referencing the ID, which is not always a meaningful value depending on the resource type.

Additionally, this will also make it possible to match against the new `sao` location (or future locations with special requirements) without having to know what custom ID suffix was given to it.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Closes #184.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
