### PR TITLE
Datasource Backups : fix schema mismatch

### DIFF
--- a/.github/workflows/nightly-acceptance.yml
+++ b/.github/workflows/nightly-acceptance.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           go-version: '^1.17.0'
 
-      - run: go test -v ./vultr -timeout 60m
+      - run: go test -v ./vultr -timeout 120m
         id: test
         env:
           TF_ACC: ${{ secrets.TF_ACC }}

--- a/vultr/data_source_vultr_backup.go
+++ b/vultr/data_source_vultr_backup.go
@@ -2,16 +2,15 @@ package vultr
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vultr/govultr/v2"
 )
 
 func dataSourceVultrBackup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVultrBackupRead,
+		ReadContext: dataSourceVultrBackupRead,
 		Schema: map[string]*schema.Schema{
 			"filter": dataSourceFiltersSchema(),
 			"backups": {
@@ -23,34 +22,34 @@ func dataSourceVultrBackup() *schema.Resource {
 	}
 }
 
-func dataSourceVultrBackupRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVultrBackupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Client).govultrClient()
 
 	filters, filtersOk := d.GetOk("filter")
 
 	if !filtersOk {
-		return fmt.Errorf("issue with filter: %v", filtersOk)
+		return diag.Errorf("issue with filter: %v", filtersOk)
 	}
 
-	backupList := []govultr.Backup{}
+	var backupList []map[string]interface{}
 	f := buildVultrDataSourceFilter(filters.(*schema.Set))
 	options := &govultr.ListOptions{}
 
 	for {
 		backups, meta, err := client.Backup.List(context.Background(), options)
 		if err != nil {
-			return fmt.Errorf("Error getting backups: %v", err)
+			return diag.Errorf("error getting backups: %v", err)
 		}
 
 		for _, b := range backups {
-			// we need convert the a struct INTO a map so we can easily manipulate the data here
+			// we need convert the struct INTO a map. This allows us to easily manipulate the data here.
 			sm, err := structToMap(b)
 			if err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 
 			if filterLoop(f, sm) {
-				backupList = append(backupList, b)
+				backupList = append(backupList, sm)
 			}
 		}
 
@@ -62,19 +61,14 @@ func dataSourceVultrBackupRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if len(backupList) > 1 {
-		return errors.New("your search returned too many results. Please refine your search to be more specific")
-	}
-
 	if len(backupList) < 1 {
-		return errors.New("no results were found")
+		return diag.Errorf("no results were found")
 	}
 
-	d.SetId(backupList[0].ID)
-	d.Set("description", backupList[0].Description)
-	d.Set("date_created", backupList[0].DateCreated)
-	d.Set("size", backupList[0].Size)
-	d.Set("status", backupList[0].Status)
+	d.SetId(backupList[0]["description"].(string))
+	if err := d.Set("backups", backupList); err != nil {
+		return diag.Errorf("error setting `backups`: %#v", err)
+	}
 
 	return nil
 }

--- a/vultr/data_source_vultr_backup.go
+++ b/vultr/data_source_vultr_backup.go
@@ -42,7 +42,7 @@ func dataSourceVultrBackupRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		for _, b := range backups {
-			// we need convert the struct INTO a map. This allows us to easily manipulate the data here.
+			// We need convert the struct into a map. This allows us to easily manipulate the data here.
 			sm, err := structToMap(b)
 			if err != nil {
 				return diag.FromErr(err)

--- a/vultr/data_source_vultr_backup.go
+++ b/vultr/data_source_vultr_backup.go
@@ -36,7 +36,7 @@ func dataSourceVultrBackupRead(ctx context.Context, d *schema.ResourceData, meta
 	options := &govultr.ListOptions{}
 
 	for {
-		backups, meta, err := client.Backup.List(context.Background(), options)
+		backups, meta, err := client.Backup.List(ctx, options)
 		if err != nil {
 			return diag.Errorf("error getting backups: %v", err)
 		}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Addressed a few things here

- Fixed the mismatch between the schema and what we are trying to set. With how backups are designed we can 1+n backups that have the same description. To address this when you use the backups datasource we will take all the backups and store them in a map.
- Updated the deprecated Read to ReadContext in the schema
- Updated the nightly runs from 60m to 120m

## Related Issues
Found in nightly tests

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
