### PR TITLE
Release v2.10.0 #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.10.0 (March 25, 2022)
+Dependency:
+- updated Go v1.16 -> v1.17  [221](https://github.com/vultr/terraform-provider-vultr/pull/221)
+- updated terraform-plugin-sdk from 2.10.1 to 2.12.0 [218](https://github.com/vultr/terraform-provider-vultr/pull/218)
+- updated govultr from 2.14.1 to 2.14.2 [219](https://github.com/vultr/terraform-provider-vultr/pull/219)
+
+Enhancement:
+- vultr_resource_block : add waits for active status [222](https://github.com/vultr/terraform-provider-vultr/pull/222)
+
+
+
 ## 2.9.1 (February 2, 2022)
 Dependency:
 - updated govultr to v2.14.0 -> v2.14.1  [210](https://github.com/vultr/terraform-provider-vultr/pull/210)

--- a/example/main.tf
+++ b/example/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     vultr = {
       source = "vultr/vultr"
-      version = "2.9.1"
+      version = "2.10.0"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     vultr = {
       source = "vultr/vultr"
-      version = "2.9.1"
+      version = "2.10.0"
     }
   }
 }

--- a/website/docs/r/kubernetes.html.markdown
+++ b/website/docs/r/kubernetes.html.markdown
@@ -20,12 +20,12 @@ Create a new VKE cluster:
 resource "vultr_kubernetes" "k8" {
   region = "ewr"
   label     = "tf-test"
-  version = "v1.20.11+1"
+  version = "v1.23.5+1"
 
   node_pools {
     node_quantity = 1
     plan = "vc2-2c-4gb"
-    label = "my label"
+    label = "my-label"
   }
 } 
 ```

--- a/website/docs/r/kubernetes_node_pools.html.markdown
+++ b/website/docs/r/kubernetes_node_pools.html.markdown
@@ -19,8 +19,8 @@ resource "vultr_kubernetes_node_pools" "np-1" {
     cluster_id = vultr_kubernetes.k8.id
     node_quantity = 1
     plan = "vc2-2c-4gb"
-    label = "my label"
-    tag = "my tag"
+    label = "my-label"
+    tag = "my-tag"
 }
 
 ```


### PR DESCRIPTION
## 2.10.0 (March 25, 2022)
Dependency:
- updated Go v1.16 -> v1.17  [221](https://github.com/vultr/terraform-provider-vultr/pull/221)
- updated terraform-plugin-sdk from 2.10.1 to 2.12.0 [218](https://github.com/vultr/terraform-provider-vultr/pull/218)
- updated govultr from 2.14.1 to 2.14.2 [219](https://github.com/vultr/terraform-provider-vultr/pull/219)

Enhancement:
- vultr_resource_block : add waits for active status [222](https://github.com/vultr/terraform-provider-vultr/pull/222)
