### PR TITLE
Warn that updating hostname triggers reinstall

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -115,9 +115,10 @@ func resourceVultrInstance() *schema.Resource {
 				Default:  false,
 			},
 			"hostname": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "Changing the hostname after initial deployment will trigger a reinstall",
 			},
 			"tag": {
 				Type:     schema.TypeString,

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -41,6 +41,8 @@ resource "vultr_instance" "my_instance" {
 
 ## Argument Reference
 
+~> Updating `hostname` after initial deployment will trigger a reinstall of the instance. This will wipe all data on your instance but IPs will remain. https://www.vultr.com/api/#operation/reinstall-instance
+
 The following arguments are supported:
 
 * `region` - (Required) The ID of the region that the instance is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Given that updating the `hostname` via the API can only be done via a reinstall of the instance. We should warn/inform users in the documentation that this is what will occur.

We could do `forceNew` on hostname however that will result in TF destroying the current instance and deploying a new one. This would result in changing of IP address.

## Related Issues
n/a
### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
