### PR TITLE
Resource Kubernetes : fix labeling on cluster updates

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -169,14 +169,13 @@ func resourceVultrKubernetesRead(ctx context.Context, d *schema.ResourceData, me
 func resourceVultrKubernetesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Client).govultrClient()
 
-	req := &govultr.ClusterReqUpdate{}
-
 	if d.HasChange("label") {
+		req := &govultr.ClusterReqUpdate{}
 		req.Label = d.Get("label").(string)
-	}
 
-	if err := client.Kubernetes.UpdateCluster(ctx, d.Id(), req); err != nil {
-		return diag.Errorf("error updating vke cluster (%v): %v", d.Id(), err)
+		if err := client.Kubernetes.UpdateCluster(ctx, d.Id(), req); err != nil {
+			return diag.Errorf("error updating vke cluster (%v): %v", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("node_pools") {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
On updates, we send always send a cluster req update which will empty out the label. 

Adjusting the logic to only send updates if the label has changed.


Tested this locally and it will only update the label if there is a change on the label itself.

## Related Issues
#234 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
