### PR TITLE
Update example and docs to apply without error.

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -24,6 +24,9 @@ resource "vultr_instance" "my_instance" {
   ddos_protection        = true
   tag                    = "tag"
   firewall_group_id      = vultr_firewall_group.fwg.id
+  backups_type {
+    type = "daily"
+  }
 }
 
 resource "vultr_firewall_group" "fwg" {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -34,6 +34,9 @@ resource "vultr_instance" "my_instance" {
 	hostname = "my-instance-hostname"
 	enable_ipv6 = true
 	backups = "enabled"
+	backups_schedule {
+	        type = "daily"
+	}
 	ddos_protection = true
 	activation_email = false
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Updates docs and examples to prevent the following error on a `terraform apply`:

```
Error: Backups are set to enabled please provide a backups_schedule

  on instance.tf line 29, in resource "vultr_instance" "my_instance":
  29: resource "vultr_instance" "my_instance" {
```

A missing `backups_schedule`argument in this scenario isn't caught by `validate` or `plan` but on the `apply`

Worth noting that this is mentioned in the docs, this PR is just syncing the examples up:

> if `backups` are enabled this field is mandatory.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
  * `terraform fmt main.tf` formatted a couple of lines but none that I added so I didn't commit those changes. 
* [x] Have you successfully ran tests with your changes locally?
