### PR TITLE
Update govultr and add support for reserved IP label updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/vultr/govultr/v2 v2.17.1
+	github.com/vultr/govultr/v2 v2.17.2
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )
 

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vultr/govultr/v2 v2.17.1 h1:UBmotwA0mkGtyJMakUF9jhLH/W3mN5wfGRn543i/BCA=
-github.com/vultr/govultr/v2 v2.17.1/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
+github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/github.com/vultr/govultr/v2/CHANGELOG.md
+++ b/vendor/github.com/vultr/govultr/v2/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## GoVultr v1 changelog is located [here](https://github.com/vultr/govultr/blob/v1/CHANGELOG.md)
 
+## [v2.17.2](https://github.com/vultr/govultr/compare/v2.17.1...v2.17.2) (2022-06-13)
+
+### Enhancement
+* Reserved IP: Add support for updating label [227](https://github.com/vultr/govultr/pull/227)
+
 ## [v2.17.1](https://github.com/vultr/govultr/compare/v2.17.0...v2.17.1) (2022-06-02)
 * Plans: Add GPU specific fields to plan struct [224](https://github.com/vultr/govultr/pull/224)
 

--- a/vendor/github.com/vultr/govultr/v2/govultr.go
+++ b/vendor/github.com/vultr/govultr/v2/govultr.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	version     = "2.17.1"
+	version     = "2.17.2"
 	defaultBase = "https://api.vultr.com"
 	userAgent   = "govultr/" + version
 	rateLimit   = 500 * time.Millisecond

--- a/vendor/github.com/vultr/govultr/v2/reserved_ip.go
+++ b/vendor/github.com/vultr/govultr/v2/reserved_ip.go
@@ -14,6 +14,7 @@ const ripPath = "/v2/reserved-ips"
 // Link : https://www.vultr.com/api/#tag/reserved-ip
 type ReservedIPService interface {
 	Create(ctx context.Context, ripCreate *ReservedIPReq) (*ReservedIP, error)
+	Update(ctx context.Context, id string, ripUpdate *ReservedIPUpdateReq) (*ReservedIP, error)
 	Get(ctx context.Context, id string) (*ReservedIP, error)
 	Delete(ctx context.Context, id string) error
 	List(ctx context.Context, options *ListOptions) ([]ReservedIP, *Meta, error)
@@ -48,6 +49,11 @@ type ReservedIPReq struct {
 	InstanceID string `json:"instance_id,omitempty"`
 }
 
+// ReservedIPUpdateReq represents the parameters for updating a Reserved IP on Vultr
+type ReservedIPUpdateReq struct {
+	Label *string `json:"label"`
+}
+
 type reservedIPsBase struct {
 	ReservedIPs []ReservedIP `json:"reserved_ips"`
 	Meta        *Meta        `json:"meta"`
@@ -66,6 +72,22 @@ type ReservedIPConvertReq struct {
 // Create adds the specified reserved IP to your Vultr account
 func (r *ReservedIPServiceHandler) Create(ctx context.Context, ripCreate *ReservedIPReq) (*ReservedIP, error) {
 	req, err := r.client.NewRequest(ctx, http.MethodPost, ripPath, ripCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	rip := new(reservedIPBase)
+	if err = r.client.DoWithContext(ctx, req, rip); err != nil {
+		return nil, err
+	}
+
+	return rip.ReservedIP, nil
+}
+
+// Update updates label on the Reserved IP
+func (r *ReservedIPServiceHandler) Update(ctx context.Context, id string, ripUpdate *ReservedIPUpdateReq) (*ReservedIP, error) {
+	uri := fmt.Sprintf("%s/%s", ripPath, id)
+	req, err := r.client.NewRequest(ctx, http.MethodPatch, uri, ripUpdate)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/vmihailenco/msgpack/v4/codes
 github.com/vmihailenco/tagparser
 github.com/vmihailenco/tagparser/internal
 github.com/vmihailenco/tagparser/internal/parser
-# github.com/vultr/govultr/v2 v2.17.1
+# github.com/vultr/govultr/v2 v2.17.2
 ## explicit; go 1.17
 github.com/vultr/govultr/v2
 # github.com/zclconf/go-cty v1.10.0

--- a/vultr/resource_vultr_reserved_ip.go
+++ b/vultr/resource_vultr_reserved_ip.go
@@ -35,7 +35,6 @@ func resourceVultrReservedIP() *schema.Resource {
 			"label": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Default:  "",
 			},
 			"instance_id": {
@@ -106,10 +105,10 @@ func resourceVultrReservedIPRead(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceVultrReservedIPUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChange("instance_id") {
-		client := meta.(*Client).govultrClient()
+	client := meta.(*Client).govultrClient()
 
-		log.Printf("[INFO] Updating Reserved IP: %s", d.Id())
+	if d.HasChange("instance_id") {
+		log.Printf("[INFO] Updating Reserved IP instance: %s", d.Id())
 
 		old, newVal := d.GetChange("instance_id")
 
@@ -122,6 +121,18 @@ func resourceVultrReservedIPUpdate(ctx context.Context, d *schema.ResourceData, 
 			if err := client.ReservedIP.Attach(ctx, d.Id(), newVal.(string)); err != nil {
 				return diag.Errorf("error attaching Reserved IP (%s): %v", d.Id(), err)
 			}
+		}
+	}
+
+	if d.HasChange("label") {
+		log.Printf("[INFO] Updating Reserved IP label: %s", d.Id())
+
+		req := &govultr.ReservedIPUpdateReq{
+			Label: govultr.StringToStringPtr(d.Get("label").(string)),
+		}
+
+		if _, err := client.ReservedIP.Update(ctx, d.Id(), req); err != nil {
+			return diag.Errorf("error updating reserved IP %s : %s", d.Id(), err.Error())
 		}
 	}
 

--- a/vultr/resource_vultr_reserved_ip_test.go
+++ b/vultr/resource_vultr_reserved_ip_test.go
@@ -109,6 +109,33 @@ func TestAccVultrReservedIPIPv6(t *testing.T) {
 	})
 }
 
+func TestAccVultrReservedIPLabelUpdate(t *testing.T) {
+	rLabel := acctest.RandomWithPrefix("tf-rip-rs")
+	rLabelUpdated := rLabel + "_updated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVultrReservedIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVultrReservedIPConfigLabel(rLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVultrReservedIPExists("vultr_reserved_ip.foo"),
+					resource.TestCheckResourceAttr("vultr_reserved_ip.foo", "label", rLabel),
+				),
+			},
+			{
+				Config: testAccVultrReservedIPConfigLabel(rLabelUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVultrReservedIPExists("vultr_reserved_ip.foo"),
+					resource.TestCheckResourceAttr("vultr_reserved_ip.foo", "label", rLabelUpdated),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVultrReservedIPDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vultr_reserved_ip" {
@@ -146,6 +173,16 @@ func testAccCheckVultrReservedIPExists(n string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func testAccVultrReservedIPConfigLabel(label string) string {
+	return fmt.Sprintf(`
+
+   resource "vultr_reserved_ip" "foo" {
+       label     = "%s"
+       region    = "ewr"
+       ip_type   = "v4"
+   }`, label)
 }
 
 func testAccVultrReservedIPConfig(rServerLabel, label, ipType string) string {

--- a/vultr/resource_vultr_reserved_ip_test.go
+++ b/vultr/resource_vultr_reserved_ip_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccVultrReservedIPIPv4(t *testing.T) {
 	rServerLabel := acctest.RandomWithPrefix("tf-vps-rip4")
 	rLabel := acctest.RandomWithPrefix("tf-rip4-rs")
+	rLabelUpdated := rLabel + "_updated"
 	ipType := "v4"
 
 	resource.Test(t, resource.TestCase{
@@ -32,10 +33,10 @@ func TestAccVultrReservedIPIPv4(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVultrReservedIPConfigAttach(rServerLabel, rLabel, ipType),
+				Config: testAccVultrReservedIPConfigAttach(rServerLabel, rLabelUpdated, ipType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVultrReservedIPExists("vultr_reserved_ip.foo"),
-					resource.TestCheckResourceAttr("vultr_reserved_ip.foo", "label", rLabel),
+					resource.TestCheckResourceAttr("vultr_reserved_ip.foo", "label", rLabelUpdated),
 					resource.TestCheckResourceAttr("vultr_reserved_ip.foo", "ip_type", ipType),
 					resource.TestCheckResourceAttrSet("vultr_reserved_ip.foo", "region"),
 					resource.TestCheckResourceAttrSet("vultr_reserved_ip.foo", "subnet"),

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 `backups_schedule` supports the following:
 
-* `type` - Type of backup schedule Possible values are `daily`, `weekly`, `monthly`, `daily_alt_event`, or `daily_alt_odd`.
+* `type` - Type of backup schedule Possible values are `daily`, `weekly`, `monthly`, `daily_alt_even`, or `daily_alt_odd`.
 * `hour` - (Optional) Hour of day to run in UTC.
 * `dow` - (Optional) Day of week to run. `1 = Sunday`, `2 = Monday`, `3 = Tuesday`, `4 = Wednesday`, `5 = Thursday`, `6 = Friday`, `7 = Saturday`
 * `dom` - (Optional) Day of month to run. Use values between 1 and 28.

--- a/website/docs/r/reverse_ipv6.html.markdown
+++ b/website/docs/r/reverse_ipv6.html.markdown
@@ -25,8 +25,8 @@ resource "vultr_instance" "my_server" {
 }
 
 resource "vultr_reverse_ipv6" "my_reverse_ipv6" {
-	instance_id = "${vultr_server.my_server.id}"
-	ip = "${vultr_server.my_server.v6_networks[0].v6_main_ip}"
+	instance_id = "${vultr_instance.my_server.id}"
+	ip = "${vultr_instance.my_server.v6_networks[0].v6_main_ip}"
 	reverse = "host.example.com"
 }
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Bump govultr to v2.17.2 which adds support for updating the label on a reserved IP.  Fixes some documentation typos as well.

### Related issues:
Fixes issues #266 & #267 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
