### PR TITLE
Update bare_metal_server resource documentation regarding reserved IPs

### DIFF
--- a/website/docs/r/bare_metal_server.html.markdown
+++ b/website/docs/r/bare_metal_server.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `tag` - (Deprecated: use `tags` instead) (Optional) The tag to assign to the server.
 * `tags` - (Optional) A list of tags to apply to the servier.
 * `label` - (Optional) A label for the server.
-* `reserved_ipv4` - (Optional) IP address of the floating IP to use as the main IP of this server. 
+* `reserved_ipv4` - (Optional) The ID of the floating IP to use as the main IP of this server. [See Reserved IPs](https://www.vultr.com/api/#operation/list-reserved-ips)
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description
`bare_metal_server` resource documentation references using the IP address of a `reserved_ip` when attaching, but resource creation fails as the ID is what is actually required.
