### PR TITLE
Add instances data source

### DIFF
--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -252,7 +252,9 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId("instances")
-	d.Set("instances", serverList)
+	if err := d.Set("instances", serverList); err != nil {
+		return diag.Errorf("error setting `instances`: %#v", err)
+	}
 
 	return nil
 }

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -1,0 +1,267 @@
+package vultr
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vultr/govultr/v2"
+)
+
+func dataSourceVultrInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVultrInstancesRead,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ram": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"disk": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"main_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vcpu_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"date_created": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"allowed_bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"netmask_v4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_v4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"power_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plan": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"v6_network": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"v6_main_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"v6_network_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"label": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kvm": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"backups": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"os_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"app_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"firewall_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"features": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"backups_schedule": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_network_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vpc_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+
+	filters, filtersOk := d.GetOk("filter")
+
+	if !filtersOk {
+		return diag.Errorf("issue with filter: %v", filtersOk)
+	}
+
+	serverList := make([]interface{}, 0)
+	f := buildVultrDataSourceFilter(filters.(*schema.Set))
+	options := &govultr.ListOptions{}
+	for {
+		servers, meta, err := client.Instance.List(ctx, options)
+		if err != nil {
+			return diag.Errorf("error getting servers: %v", err)
+		}
+
+		for _, server := range servers {
+			// we need convert the a struct INTO a map so we can easily manipulate the data here
+			sm, err := structToMap(server)
+
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			if filterLoop(f, sm) {
+				schedule, err := client.Instance.GetBackupSchedule(ctx, server.ID)
+				if err != nil {
+					return diag.Errorf("error getting backup schedule: %v", err)
+				}
+
+				bsInfo := map[string]interface{}{
+					"type": schedule.Type,
+					"hour": strconv.Itoa(schedule.Hour),
+					"dom":  strconv.Itoa(schedule.Dom),
+					"dow":  strconv.Itoa(schedule.Dow),
+				}
+
+				vpcs, err := getVPCs(client, server.ID)
+				if err != nil {
+					return diag.Errorf(err.Error())
+				}
+
+				serverList = append(serverList, map[string]interface{}{
+					"id":                  server.ID,
+					"os":                  server.Os,
+					"ram":                 server.RAM,
+					"disk":                server.Disk,
+					"main_ip":             server.MainIP,
+					"vcpu_count":          server.VCPUCount,
+					"region":              server.Region,
+					"date_created":        server.DateCreated,
+					"allowed_bandwidth":   server.AllowedBandwidth,
+					"netmask_v4":          server.NetmaskV4,
+					"gateway_v4":          server.GatewayV4,
+					"status":              server.Status,
+					"power_status":        server.PowerStatus,
+					"server_status":       server.ServerStatus,
+					"plan":                server.Plan,
+					"label":               server.Label,
+					"internal_ip":         server.InternalIP,
+					"kvm":                 server.KVM,
+					"tag":                 server.Tag,
+					"tags":                server.Tags,
+					"os_id":               server.OsID,
+					"app_id":              server.AppID,
+					"image_id":            server.ImageID,
+					"firewall_group_id":   server.FirewallGroupID,
+					"v6_network":          server.V6Network,
+					"v6_main_ip":          server.V6MainIP,
+					"v6_network_size":     server.V6NetworkSize,
+					"features":            server.Features,
+					"hostname":            server.Hostname,
+					"backups":             backupStatus(schedule.Enabled),
+					"backups_schedule":    bsInfo,
+					"private_network_ids": vpcs,
+					"vpc_ids":             vpcs,
+				})
+			}
+		}
+
+		if meta.Links.Next == "" {
+			break
+		} else {
+			options.Cursor = meta.Links.Next
+			continue
+		}
+	}
+
+	if len(serverList) < 1 {
+		return diag.Errorf("no results were found")
+	}
+
+	d.SetId("instances")
+	d.Set("instances", serverList)
+
+	return nil
+}

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -256,10 +256,6 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	if len(serverList) < 1 {
-		return diag.Errorf("no results were found")
-	}
-
 	d.SetId("instances")
 	d.Set("instances", serverList)
 

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -111,10 +111,6 @@ func dataSourceVultrInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"tag": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"tags": {
 							Type:     schema.TypeSet,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -229,7 +225,6 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 					"label":               server.Label,
 					"internal_ip":         server.InternalIP,
 					"kvm":                 server.KVM,
-					"tag":                 server.Tag,
 					"tags":                server.Tags,
 					"os_id":               server.OsID,
 					"app_id":              server.AppID,

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vultr/govultr/v2"
+	"github.com/vultr/govultr/v3"
 )
 
 func dataSourceVultrInstances() *schema.Resource {
@@ -175,7 +175,7 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	f := buildVultrDataSourceFilter(filters.(*schema.Set))
 	options := &govultr.ListOptions{}
 	for {
-		servers, meta, err := client.Instance.List(ctx, options)
+		servers, meta, _, err := client.Instance.List(ctx, options)
 		if err != nil {
 			return diag.Errorf("error getting servers: %v", err)
 		}
@@ -189,7 +189,7 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 			}
 
 			if filterLoop(f, sm) {
-				schedule, err := client.Instance.GetBackupSchedule(ctx, server.ID)
+				schedule, _, err := client.Instance.GetBackupSchedule(ctx, server.ID)
 				if err != nil {
 					return diag.Errorf("error getting backup schedule: %v", err)
 				}

--- a/vultr/data_source_vultr_instances_test.go
+++ b/vultr/data_source_vultr_instances_test.go
@@ -36,7 +36,7 @@ func TestAccVultrInstances(t *testing.T) {
 					resource.TestCheckResourceAttrSet(name, "instances.0.plan"),
 					resource.TestCheckResourceAttrSet(name, "instances.0.label"),
 					resource.TestCheckResourceAttrSet(name, "instances.0.kvm"),
-					resource.TestCheckResourceAttrSet(name, "instances.0.tag"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.tags.0"),
 					resource.TestCheckResourceAttrSet(name, "instances.0.os_id"),
 					resource.TestCheckResourceAttrSet(name, "instances.0.app_id"),
 					resource.TestCheckResourceAttrSet(name, "instances.0.v6_main_ip"),
@@ -59,7 +59,7 @@ func testAccCheckVultrInstances(label string) string {
 			hostname = "testing-the-hostname"
 			enable_ipv6 = true
 			ddos_protection = true
-			tag = "even better tag"
+			tags = ["my_tag"]
 			backups = "enabled"
 			backups_schedule{
 				type = "weekly"

--- a/vultr/data_source_vultr_instances_test.go
+++ b/vultr/data_source_vultr_instances_test.go
@@ -1,0 +1,75 @@
+package vultr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVultrInstances(t *testing.T) {
+	t.Parallel()
+	rLabel := acctest.RandomWithPrefix("tf-test-ds")
+	name := "data.vultr_instances.instances"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckVultrInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVultrInstances(rLabel),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "instances.0.os"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.ram"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.disk"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.main_ip"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.vcpu_count"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.region"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.date_created"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.allowed_bandwidth"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.netmask_v4"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.gateway_v4"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.power_status"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.server_status"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.plan"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.label"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.kvm"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.tag"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.os_id"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.app_id"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.v6_main_ip"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.v6_network"),
+					resource.TestCheckResourceAttrSet(name, "instances.0.v6_network_size"),
+					resource.TestCheckResourceAttr(name, "instances.0.backups", "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVultrInstances(label string) string {
+	return fmt.Sprintf(`
+		resource "vultr_instance" "test" {
+			plan = "vc2-1c-1gb"
+			region = "sea"
+			os_id = "167"
+			label = "%s"
+			hostname = "testing-the-hostname"
+			enable_ipv6 = true
+			ddos_protection = true
+			tag = "even better tag"
+			backups = "enabled"
+			backups_schedule{
+				type = "weekly"
+			}
+		}
+
+		data "vultr_instances" "instances" {
+			filter {
+				name = "label"
+				values = ["${vultr_instance.test.label}"]
+			}
+		}`, label)
+}

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -50,6 +50,7 @@ func Provider() *schema.Provider {
 			"vultr_reverse_ipv4":           dataSourceVultrReverseIPV4(),
 			"vultr_reverse_ipv6":           dataSourceVultrReverseIPV6(),
 			"vultr_instance":               dataSourceVultrInstance(),
+			"vultr_instances":              dataSourceVultrInstances(),
 			"vultr_instance_ipv4":          dataSourceVultrInstanceIPV4(),
 			"vultr_snapshot":               dataSourceVultrSnapshot(),
 			"vultr_ssh_key":                dataSourceVultrSSHKey(),


### PR DESCRIPTION
## Description

This new datasource allows us to receive more than one instance from the API, the usecase for this includes searching for instances in a specific region or searching for instances with a specific tag.

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
