### PR TITLE
data_source_vultr_ssh_key: export the key ID

### DIFF
--- a/vultr/data_source_vultr_ssh_key.go
+++ b/vultr/data_source_vultr_ssh_key.go
@@ -13,6 +13,10 @@ func dataSourceVultrSSHKey() *schema.Resource {
 		ReadContext: dataSourceVultrSSHKeyRead,
 		Schema: map[string]*schema.Schema{
 			"filter": dataSourceFiltersSchema(),
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -44,7 +48,7 @@ func dataSourceVultrSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta
 	options := &govultr.ListOptions{}
 
 	for {
-		sshKeys, meta,_, err := client.SSHKey.List(ctx, options)
+		sshKeys, meta, _, err := client.SSHKey.List(ctx, options)
 		if err != nil {
 			return diag.Errorf("error getting SSH keys: %v", err)
 		}

--- a/website/docs/d/ssh_key.html.markdown
+++ b/website/docs/d/ssh_key.html.markdown
@@ -38,6 +38,7 @@ The `filter` block supports the following:
 
 The following attributes are exported:
 
+* `id` - The ID of the SSH key.
 * `name` - The name of the SSH key.
 * `ssh_key` - The public SSH key.
 * `date_created` - The date the SSH key was added to your Vultr account.


### PR DESCRIPTION
## Description

Provisioning new instances requires the SSH key ID of an existing key, this lets users pull it from a data source to pass as an argument to instance/metal resources.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?

* [ ] Have you successfully ran tests with your changes locally?

No, the linter itself fails without a gofmt of the existing codebase, which seems too much for this small change.