### PR TITLE
Add delete retries

### DIFF
--- a/vultr/resource_vultr_load_balancer.go
+++ b/vultr/resource_vultr_load_balancer.go
@@ -533,13 +533,15 @@ func resourceVultrLoadBalancerDelete(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Deleting load balancer: %v", d.Id())
 
-	// detach
+	// items we should detach before we destroy
+	// instances and firewall rules are default "null" if not present in LoadBalancerReq
 	detachConfig := &govultr.LoadBalancerReq{}
 
 	if _, vpcOK := d.GetOk("vpc"); vpcOK {
 		detachConfig.VPC = govultr.StringToStringPtr("")
 	}
 
+	// send update to perform detach
 	if err := client.LoadBalancer.Update(ctx, d.Id(), detachConfig); err != nil {
 		return diag.Errorf("error detaching VPC from load balancer before deletion (%v): %v", d.Id(), err)
 	}

--- a/vultr/resource_vultr_load_balancer.go
+++ b/vultr/resource_vultr_load_balancer.go
@@ -533,6 +533,17 @@ func resourceVultrLoadBalancerDelete(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Deleting load balancer: %v", d.Id())
 
+	// detach
+	detachConfig := &govultr.LoadBalancerReq{}
+
+	if _, vpcOK := d.GetOk("vpc"); vpcOK {
+		detachConfig.VPC = govultr.StringToStringPtr("")
+	}
+
+	if err := client.LoadBalancer.Update(ctx, d.Id(), detachConfig); err != nil {
+		return diag.Errorf("error detaching VPC from load balancer before deletion (%v): %v", d.Id(), err)
+	}
+
 	if err := client.LoadBalancer.Delete(ctx, d.Id()); err != nil {
 		return diag.Errorf("error deleting load balancer %v : %v", d.Id(), err)
 	}

--- a/vultr/resource_vultr_vpc.go
+++ b/vultr/resource_vultr_vpc.go
@@ -125,7 +125,7 @@ func resourceVultrVPCDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[INFO] Deleting VPC: %s", d.Id())
 
-	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
 		err := client.VPC.Delete(ctx, d.Id())
 
 		if err == nil {

--- a/vultr/resource_vultr_vpc.go
+++ b/vultr/resource_vultr_vpc.go
@@ -2,10 +2,13 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vultr/govultr/v3"
@@ -121,7 +124,22 @@ func resourceVultrVPCDelete(ctx context.Context, d *schema.ResourceData, meta in
 	client := meta.(*Client).govultrClient()
 
 	log.Printf("[INFO] Deleting VPC: %s", d.Id())
-	if err := client.VPC.Delete(ctx, d.Id()); err != nil {
+
+	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+		err := client.VPC.Delete(ctx, d.Id())
+
+		if err == nil {
+			return nil
+		}
+
+		if strings.Contains(err.Error(), "VPC is attached") {
+			return retry.RetryableError(fmt.Errorf("cannot remove attached VPC: %s", err.Error()))
+		}
+
+		return retry.NonRetryableError(err)
+	})
+
+	if err != nil {
 		return diag.Errorf("error destroying VPC (%s): %v", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The tests were failing because of the VPC not being fully detached from a load balancer before the delete command was issued.  Essentially, the load balancers are too slow to shutdown and delete so the VPC remains in an attached state when the delete command is sent by Terraform.  This PR does two things to help in the case that a VPC is attached to a load balancer:
- When deleting, issue an update against a load balancer to detach the VPC
- Add a retry on the VPC resource to check the error returned from the API and re-issue the delete command after a short wait.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Closes #355 
A similar solution might work for #348 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
