### PR TITLE
Bare Metal Persistent PXE

### DIFF
--- a/vendor/github.com/vultr/govultr/v3/bare_metal_server.go
+++ b/vendor/github.com/vultr/govultr/v3/bare_metal_server.go
@@ -90,18 +90,20 @@ type BareMetalCreate struct {
 	// Deprecated: Tag should no longer be used. Instead, use Tags.
 	Tag           string   `json:"tag,omitempty"`
 	ReservedIPv4  string   `json:"reserved_ipv4,omitempty"`
-	PersistentPxe *bool    `json:"persistent_pxe,omitempty"`
+	PersistentPXE *bool    `json:"persistent_pxe,omitempty"`
 	Tags          []string `json:"tags"`
 }
 
 // BareMetalUpdate represents the optional parameters that can be set when updating a Bare Metal server
 type BareMetalUpdate struct {
-	OsID       int    `json:"os_id,omitempty"`
-	EnableIPv6 *bool  `json:"enable_ipv6,omitempty"`
-	Label      string `json:"label,omitempty"`
-	AppID      int    `json:"app_id,omitempty"`
-	ImageID    string `json:"image_id,omitempty"`
-	UserData   string `json:"user_data,omitempty"`
+	OsID          int    `json:"os_id,omitempty"`
+	EnableIPv6    *bool  `json:"enable_ipv6,omitempty"`
+	Label         string `json:"label,omitempty"`
+	AppID         int    `json:"app_id,omitempty"`
+	ImageID       string `json:"image_id,omitempty"`
+	UserData      string `json:"user_data,omitempty"`
+	PersistentPXE *bool  `json:"persistent_pxe,omitempty"`
+
 	// Deprecated: Tag should no longer be used. Instead, use Tags.
 	Tag  *string  `json:"tag,omitempty"`
 	Tags []string `json:"tags"`

--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -54,6 +54,11 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				ForceNew: true,
 				Default:  "",
 			},
+			"persistent_pxe": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+			},
 			"snapshot_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -203,6 +208,7 @@ func resourceVultrBareMetalServerCreate(ctx context.Context, d *schema.ResourceD
 		ActivationEmail: govultr.BoolToBoolPtr(d.Get("activation_email").(bool)),
 		Hostname:        d.Get("hostname").(string),
 		ReservedIPv4:    d.Get("reserved_ipv4").(string),
+		PersistentPXE:   govultr.BoolToBoolPtr(d.Get("persistent").(bool)),
 	}
 
 	switch osOption {
@@ -324,9 +330,10 @@ func resourceVultrBareMetalServerUpdate(ctx context.Context, d *schema.ResourceD
 	client := meta.(*Client).govultrClient()
 
 	req := &govultr.BareMetalUpdate{
-		Label:      d.Get("label").(string),
-		Tags:       []string{},
-		EnableIPv6: govultr.BoolToBoolPtr(d.Get("enable_ipv6").(bool)),
+		Label:         d.Get("label").(string),
+		Tags:          []string{},
+		EnableIPv6:    govultr.BoolToBoolPtr(d.Get("enable_ipv6").(bool)),
+		PersistentPXE: govultr.BoolToBoolPtr(d.Get("persistent_pxe").(bool)),
 	}
 
 	if d.HasChange("app_id") {

--- a/vultr/resource_vultr_bare_metal_server_test.go
+++ b/vultr/resource_vultr_bare_metal_server_test.go
@@ -129,6 +129,7 @@ func testAccVultrBareMetalServerConfigBasic(rInt int, rSSH, rName string) string
 			activation_email = false
 			ssh_key_ids = ["${vultr_ssh_key.foo.id}"]
 			script_id = "${vultr_startup_script.foo.id}"
+			persistent_pxe = true
 			user_data = "my user data"
 			label = "%s"
 			hostname = "%s"
@@ -147,6 +148,7 @@ func testAccVultrBareMetalServerConfigUpdate(rInt int, rSSH, rName string) strin
 			ssh_key_ids = ["${vultr_ssh_key.foo.id}"]
 			script_id = "${vultr_startup_script.foo.id}"
 			user_data = "my user data"
+			persistent_pxe = true
 			label = "%s-update"
 			hostname = "%s"
 			tags = [ "test tag", "another tag" ]


### PR DESCRIPTION
## Description
This adds the option `persistent_pxe` as documented by the [create metal API](https://www.vultr.com/api/#operation/create-baremetal). It also adds to this flag to the update flow, which appears to be supported by the govultr package but not documented in the [update metal API](https://www.vultr.com/api/#operation/update-baremetal). 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
