### PR TITLE
Add missing vpc_id property to managed database read replicas

### DIFF
--- a/vultr/database.go
+++ b/vultr/database.go
@@ -92,6 +92,10 @@ func readReplicaSchema(isReadReplica bool) map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"vpc_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"maintenance_dow": {
 			Type:     schema.TypeString,
 			Computed: true,


### PR DESCRIPTION
## Description
There is an issue with read replicas and the `vpc_id` property that was causing a panic as well as failed tests. This PR adds the missing item. Tested `TestAccVultrDatabaseReplicaUpdate` again to validate.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
