### PR TITLE
Add support for public/private DBaaS hostnames

### DIFF
--- a/vultr/data_source_vultr_database.go
+++ b/vultr/data_source_vultr_database.go
@@ -73,6 +73,10 @@ func dataSourceVultrDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"user": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -240,6 +244,12 @@ func dataSourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("unable to set resource database `host` read value: %v", err)
 	}
 
+	if databaseList[0].PublicHost != "" {
+		if err := d.Set("public_host", databaseList[0].PublicHost); err != nil {
+			return diag.Errorf("unable to set resource database `public_host` read value: %v", err)
+		}
+	}
+
 	if err := d.Set("user", databaseList[0].User); err != nil {
 		return diag.Errorf("unable to set resource database `user` read value: %v", err)
 	}
@@ -325,6 +335,7 @@ func flattenReplicas(db *govultr.Database) []map[string]interface{} {
 			"tag":                       db.ReadReplicas[v].Tag,
 			"dbname":                    db.ReadReplicas[v].DBName,
 			"host":                      db.ReadReplicas[v].Host,
+			"public_host":               db.ReadReplicas[v].PublicHost,
 			"user":                      db.ReadReplicas[v].User,
 			"password":                  db.ReadReplicas[v].Password,
 			"port":                      db.ReadReplicas[v].Port,
@@ -338,6 +349,10 @@ func flattenReplicas(db *govultr.Database) []map[string]interface{} {
 			"mysql_long_query_time":     db.ReadReplicas[v].MySQLLongQueryTime,
 			"redis_eviction_policy":     db.ReadReplicas[v].RedisEvictionPolicy,
 			"cluster_time_zone":         db.ReadReplicas[v].ClusterTimeZone,
+		}
+
+		if db.PublicHost == "" {
+			delete(r, "public_host")
 		}
 
 		if db.DatabaseEngine != "mysql" {

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -59,14 +59,17 @@ func resourceVultrDatabase() *schema.Resource {
 			},
 			"maintenance_dow": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 			"maintenance_time": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 			"cluster_time_zone": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 			"trusted_ips": {

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -134,6 +134,11 @@ func resourceVultrDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
 			"user": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -313,6 +318,12 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if err := d.Set("host", database.Host); err != nil {
 		return diag.Errorf("unable to set resource database `host` read value: %v", err)
+	}
+
+	if database.PublicHost != "" {
+		if err := d.Set("public_host", database.PublicHost); err != nil {
+			return diag.Errorf("unable to set resource database `public_host` read value: %v", err)
+		}
 	}
 
 	if err := d.Set("user", database.User); err != nil {
@@ -555,7 +566,7 @@ func resourceVultrDatabaseDelete(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func waitForDatabaseAvailable(ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}) (interface{}, error) {
+func waitForDatabaseAvailable(ctx context.Context, d *schema.ResourceData, target string, pending []string, attribute string, meta interface{}) (interface{}, error) { // nolint:dupl,lll
 	log.Printf(
 		"[INFO] Waiting for Managed Database (%s) to have %s of %s",
 		d.Id(), attribute, target)

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -50,8 +50,10 @@ The following attributes are exported:
 * `tag` - The managed database's tag.
 * `database_engine` - The database engine of the managed database.
 * `database_engine_version` - The database engine version of the managed database.
+* `vpc_id` - The ID of the VPC Network attached to the Managed Database.
 * `dbname` - The managed database's default logical database.
 * `host` - The hostname assigned to the managed database.
+* `public_host` - The public hostname assigned to the managed database (VPC-attached only).
 * `user` - The primary admin user for the managed database.
 * `password` - The password for the managed database's primary admin user.
 * `port` - The connection port for the managed database.

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `database_engine` - (Required) The database engine of the new managed database.
 * `database_engine_version` - (Required) The database engine version of the new managed database.
 * `label` - (Required) A label for the managed database.
+* `vpc_id` - (Optional) The ID of the VPC Network to attach to the Managed Database.
 * `tag` - (Optional) The tag to assign to the managed database.
 * `maintenance_dow` - (Optional) The preferred maintenance day of week for the managed database.
 * `maintenance_time` - (Optional) The preferred maintenance time for the managed database.
@@ -82,8 +83,10 @@ The following attributes are exported:
 * `tag` - The managed database's tag.
 * `database_engine` - The database engine of the managed database.
 * `database_engine_version` - The database engine version of the managed database.
+* `vpc_id` - The ID of the VPC Network attached to the Managed Database.
 * `dbname` - The managed database's default logical database.
 * `host` - The hostname assigned to the managed database.
+* `public_host` - The public hostname assigned to the managed database (VPC-attached only).
 * `user` - The primary admin user for the managed database.
 * `password` - The password for the managed database's primary admin user.
 * `port` - The connection port for the managed database.


### PR DESCRIPTION
## Description
This PR brings our Terraform provider up to speed with the rest of our open source libraries and adds support for showing both public and private hostnames for Managed Database resources. The `public_host` field is only shown when a VPC is attached and omitted otherwise.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
