### PR TITLE
Fix bug with flattening non-FerretDB DBaaS replicas

### DIFF
--- a/vultr/data_source_vultr_database.go
+++ b/vultr/data_source_vultr_database.go
@@ -363,7 +363,6 @@ func flattenReplicas(db *govultr.Database) []map[string]interface{} {
 			"label":                     db.ReadReplicas[v].Label,
 			"tag":                       db.ReadReplicas[v].Tag,
 			"dbname":                    db.ReadReplicas[v].DBName,
-			"ferretdb_credentials":      flattenFerretDBCredentials(&db.ReadReplicas[v]),
 			"host":                      db.ReadReplicas[v].Host,
 			"public_host":               db.ReadReplicas[v].PublicHost,
 			"user":                      db.ReadReplicas[v].User,
@@ -381,8 +380,8 @@ func flattenReplicas(db *govultr.Database) []map[string]interface{} {
 			"cluster_time_zone":         db.ReadReplicas[v].ClusterTimeZone,
 		}
 
-		if db.DatabaseEngine != "ferretpg" {
-			delete(r, "ferretdb_credentials")
+		if db.DatabaseEngine == "ferretpg" {
+			r["ferretdb_credentials"] = flattenFerretDBCredentials(&db.ReadReplicas[v])
 		}
 
 		if db.PublicHost == "" {


### PR DESCRIPTION
## Description
Noticed some acceptance tests failing due to a bug in the Managed Database flattenReplicas function, always trying to flatten the FerretDB credentials object even if it didn't exist. Removed it from the main map/interface block and setting that separately for the correct engine type only seems to do the trick.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
