### PR TITLE
Remove deprecated SDK meta version function usage

### DIFF
--- a/vultr/config.go
+++ b/vultr/config.go
@@ -3,13 +3,15 @@ package vultr
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 	"github.com/vultr/govultr/v3"
 	"golang.org/x/oauth2"
 )
+
+const terraformSDKPath string = "github.com/hashicorp/terraform-plugin-sdk/v2"
 
 // Config is the configuration structure used to instantiate Vultr
 type Config struct {
@@ -27,9 +29,26 @@ func (c *Client) govultrClient() *govultr.Client {
 	return c.client
 }
 
+// terraformSDKVersion looks up the module version of the Terraform SDK for use
+// in the User Agent client string
+func terraformSDKVersion() string {
+	i, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "0.0.0"
+	}
+
+	for _, module := range i.Deps {
+		if module.Path == terraformSDKPath {
+			return module.Version
+		}
+	}
+
+	return "0.0.0"
+}
+
 // Client configures govultr and returns an initialized client
 func (c *Config) Client() (*Client, error) {
-	userAgent := fmt.Sprintf("Terraform/%s", meta.SDKVersionString())
+	userAgent := fmt.Sprintf("Terraform/%s", terraformSDKVersion())
 	tokenSrc := oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: c.APIKey,
 	})


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Resolve the deprecation lint error:
```
Golangci-Lint: vultr/config.go#L32
SA1019: meta.SDKVersionString is deprecated: Use Go standard library [runtime/debug] package build information instead. (staticcheck)
```

These changes will lookup the module by the path, then set the `User-Agent` string to `Terraform/` plus whatever is returned from the module.  For example:

```
User-Agent=Terraform/v2.30.0
```

If for some reason it cannot determine the version number, it will default to `v0.0.0` for the sake of consistency

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

## Testing
Set the debug output, run a command and check the value passed in the output file.
```
export TF_LOG_PATH=...
export TF_LOG=debug
terraform apply
```