### PR TITLE
Add managed firewall support for VKE

### DIFF
--- a/vultr/data_source_vultr_kubernetes.go
+++ b/vultr/data_source_vultr_kubernetes.go
@@ -49,6 +49,10 @@ func dataSourceVultrKubernetes() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"firewall_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"region": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -165,6 +169,9 @@ func dataSourceVultrKubernetesRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	if err := d.Set("ha_controlplanes", k8List[0].HAControlPlanes); err != nil {
 		return diag.Errorf("unable to set kubernetes `ha_controlplanes` read value: %v", err)
+	}
+	if err := d.Set("firewall_group_id", k8List[0].FirewallGroupID); err != nil {
+		return diag.Errorf("unable to set kubernetes `firewall_group_id` read value: %v", err)
 	}
 	if err := d.Set("region", k8List[0].Region); err != nil {
 		return diag.Errorf("unable to set kubernetes `region` read value: %v", err)

--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -45,6 +45,12 @@ func resourceVultrKubernetes() *schema.Resource {
 				Default:  false,
 				ForceNew: true,
 			},
+			"enable_firewall": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 
 			"node_pools": {
 				Type:     schema.TypeList,
@@ -77,6 +83,10 @@ func resourceVultrKubernetes() *schema.Resource {
 				Computed: true,
 			},
 			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"firewall_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -122,6 +132,7 @@ func resourceVultrKubernetesCreate(ctx context.Context, d *schema.ResourceData, 
 		Region:          d.Get("region").(string),
 		Version:         d.Get("version").(string),
 		HAControlPlanes: d.Get("ha_controlplanes").(bool),
+		EnableFirewall:  d.Get("enable_firewall").(bool),
 		NodePools:       nodePoolReq,
 	}
 
@@ -213,6 +224,9 @@ func resourceVultrKubernetesRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	if err := d.Set("ha_controlplanes", vke.HAControlPlanes); err != nil {
 		return diag.Errorf("unable to set resource kubernetes `ha_controlplanes` read value: %v", err)
+	}
+	if err := d.Set("firewall_group_id", vke.FirewallGroupID); err != nil {
+		return diag.Errorf("unable to set resource kubernetes `firewall_group_id` read value: %v", err)
 	}
 
 	return nil

--- a/website/docs/d/kubernetes.html.markdown
+++ b/website/docs/d/kubernetes.html.markdown
@@ -43,6 +43,7 @@ The following attributes are exported:
 * `region` - The region your VKE cluster is deployed in.
 * `version` - The current kubernetes version your VKE cluster is running on.
 * `ha_controlplanes` - Boolean indicating whether or not the cluster has multiple, highly available controlplanes.
+* `firewall_group_id` - The ID of the firewall group managed by this cluster.
 * `status` - The overall status of the cluster.
 * `service_subnet` - IP range that services will run on this cluster.
 * `cluster_subnet` - IP range that your pods will run on in this cluster.

--- a/website/docs/r/kubernetes.html.markdown
+++ b/website/docs/r/kubernetes.html.markdown
@@ -65,6 +65,7 @@ The follow arguments are supported:
 * `version` - (Required) The version your VKE cluster you want deployed. [See Available Version](https://www.vultr.com/api/#operation/get-kubernetes-versions)
 * `label` - (Optional) The VKE clusters label.
 * `ha_controlplanes` - (Optional, Default to False) Boolean indicating if the cluster should be created with multiple, highly available controlplanes.
+* `enable_firewall` - (Optional, Default to False) Boolean indicating if the cluster should be created with a managed firewall.
 
 `node_pools` (Optional) **NOTE** There must be 1 node pool when the kubernetes resource is first created (see explanation above). It supports the following fields
 
@@ -82,6 +83,7 @@ The following attributes are exported:
 * `label` - The VKE clusters label.
 * `region` - The region your VKE cluster is deployed in.
 * `ha_controlplanes` - Boolean indicating whether or not the cluster has multiple, highly available controlplanes.
+* `firewall_group_id` - The ID of the firewall group managed by this cluster.
 * `version` - The current kubernetes version your VKE cluster is running on.
 * `status` - The overall status of the cluster.
 * `service_subnet` - IP range that services will run on this cluster.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Adds managed firewall support for VKE clusters:
- `enable_firewall` can be used as an argument to create clusters with a managed firewall.
- The ID of the managed firewall is exposed in the `firewall_group_id` attribute.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
