### PR TITLE
Support Marketplace App Variables

### DIFF
--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -118,6 +118,12 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"app_variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			// computed
 			"os": {
 				Type:     schema.TypeString,
@@ -214,6 +220,14 @@ func resourceVultrBareMetalServerCreate(ctx context.Context, d *schema.ResourceD
 		Hostname:        d.Get("hostname").(string),
 		ReservedIPv4:    d.Get("reserved_ipv4").(string),
 		PersistentPxe:   govultr.BoolToBoolPtr(d.Get("persistent").(bool)),
+	}
+
+	if appVariables, appVariablesOK := d.GetOk("app_variables"); appVariablesOK {
+		appVariablesMap := make(map[string]string)
+		for k, v := range appVariables.(map[string]interface{}) {
+			appVariablesMap[k] = v.(string)
+		}
+		req.AppVariables = appVariablesMap
 	}
 
 	switch osOption {

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -181,6 +181,12 @@ func resourceVultrInstance() *schema.Resource {
 					},
 				},
 			},
+			"app_variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			// Computed
 			"os": {
 				Type:     schema.TypeString,
@@ -305,6 +311,14 @@ func resourceVultrInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 		ReservedIPv4:    d.Get("reserved_ip_id").(string),
 		Region:          d.Get("region").(string),
 		Plan:            d.Get("plan").(string),
+	}
+
+	if appVariables, appVariablesOK := d.GetOk("app_variables"); appVariablesOK {
+		appVariablesMap := make(map[string]string)
+		for k, v := range appVariables.(map[string]interface{}) {
+			appVariablesMap[k] = v.(string)
+		}
+		req.AppVariables = appVariablesMap
 	}
 
 	// If no osOptions where selected and osID has a real value then set the osOptions to osID

--- a/website/docs/r/bare_metal_server.html.markdown
+++ b/website/docs/r/bare_metal_server.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
 * `tags` - (Optional) A list of tags to apply to the servier.
 * `label` - (Optional) A label for the server.
 * `reserved_ipv4` - (Optional) The ID of the floating IP to use as the main IP of this server. [See Reserved IPs](https://www.vultr.com/api/#operation/list-reserved-ips)
+* `app_variables` - (Optional) A map of user-supplied variable keys and values for Vultr Marketplace apps. [See List Marketplace App Variables](https://www.vultr.com/api/#tag/marketplace/operation/list-marketplace-app-variables)
 
 ## Attributes Reference
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `tags` - (Optional) A list of tags to apply to the instance.
 * `label` - (Optional) A label for the server.
 * `reserved_ip_id` - (Optional) ID of the floating IP to use as the main IP of this server.
+* `app_variables` - (Optional) A map of user-supplied variable keys and values for Vultr Marketplace apps. [See List Marketplace App Variables](https://www.vultr.com/api/#tag/marketplace/operation/list-marketplace-app-variables)
 * `backups_schedule` - (Optional) A block that defines the way backups should be scheduled. While this is an optional field if `backups` are `enabled` this field is mandatory. The configuration of a `backups_schedule` is listed below.
 
 `backups_schedule` supports the following:


### PR DESCRIPTION
## Description
This PR updates the instance and bare metal resources to support the `AppVariables` property, which allows users to create servers for Vultr marketplace apps that have user-supplied variable input on creation.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
