### PR TITLE
Allow Creating Instance Without Public IP 

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -72,6 +72,12 @@ func resourceVultrInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"disable_public_ipv4": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Don't set up a public IPv4 address when IPv6 is enabled. Will not do anything unless enable_ipv6 is also true.",
+			},
 			"private_network_ids": {
 				Type:       schema.TypeSet,
 				Optional:   true,
@@ -293,18 +299,19 @@ func resourceVultrInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	client := meta.(*Client).govultrClient()
 
 	req := &govultr.InstanceCreateReq{
-		EnableIPv6:      govultr.BoolToBoolPtr(d.Get("enable_ipv6").(bool)),
-		Label:           d.Get("label").(string),
-		Backups:         backups,
-		UserData:        base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string))),
-		ActivationEmail: govultr.BoolToBoolPtr(d.Get("activation_email").(bool)),
-		DDOSProtection:  govultr.BoolToBoolPtr(d.Get("ddos_protection").(bool)),
-		Hostname:        d.Get("hostname").(string),
-		FirewallGroupID: d.Get("firewall_group_id").(string),
-		ScriptID:        d.Get("script_id").(string),
-		ReservedIPv4:    d.Get("reserved_ip_id").(string),
-		Region:          d.Get("region").(string),
-		Plan:            d.Get("plan").(string),
+		EnableIPv6:        govultr.BoolToBoolPtr(d.Get("enable_ipv6").(bool)),
+		DisablePublicIPv4: govultr.BoolToBoolPtr(d.Get("disable_public_ipv4").(bool)),
+		Label:             d.Get("label").(string),
+		Backups:           backups,
+		UserData:          base64.StdEncoding.EncodeToString([]byte(d.Get("user_data").(string))),
+		ActivationEmail:   govultr.BoolToBoolPtr(d.Get("activation_email").(bool)),
+		DDOSProtection:    govultr.BoolToBoolPtr(d.Get("ddos_protection").(bool)),
+		Hostname:          d.Get("hostname").(string),
+		FirewallGroupID:   d.Get("firewall_group_id").(string),
+		ScriptID:          d.Get("script_id").(string),
+		ReservedIPv4:      d.Get("reserved_ip_id").(string),
+		Region:            d.Get("region").(string),
+		Plan:              d.Get("plan").(string),
 	}
 
 	// If no osOptions where selected and osID has a real value then set the osOptions to osID

--- a/vultr/resource_vultr_instance_test.go
+++ b/vultr/resource_vultr_instance_test.go
@@ -26,8 +26,8 @@ func TestAccVultrInstanceBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "label", rName),
 					resource.TestCheckResourceAttr(name, "os", "CentOS 7 x64"),
-					resource.TestCheckResourceAttr(name, "ram", "1024"),
-					resource.TestCheckResourceAttr(name, "disk", "25"),
+					resource.TestCheckResourceAttr(name, "ram", "2048"),
+					resource.TestCheckResourceAttr(name, "disk", "55"),
 					resource.TestCheckResourceAttr(name, "region", "sea"),
 					resource.TestCheckResourceAttr(name, "os_id", "167"),
 					resource.TestCheckResourceAttr(name, "status", "active"),
@@ -270,7 +270,7 @@ func testAccVultrInstanceBase(name string) string {
 		resource "vultr_instance" "test" {
 			plan = "vc2-1c-2gb"
 			region = "sea"
-			os_id = 477
+			os_id = 167
 			label = "%s"
 			hostname = "testing-the-hostname"
 			enable_ipv6 = true
@@ -291,7 +291,7 @@ func testAccVultrInstanceBaseUpdateFirewall(name string) string {
 		resource "vultr_instance" "test" {
 			plan = "vc2-1c-2gb"
 			region = "sea"
-			os_id = 477
+			os_id = 167
 			label = "%s"
 			hostname = "testing-the-hostname"
 			enable_ipv6 = true
@@ -374,7 +374,7 @@ func testAccVultrInstanceBaseUpdatedRegion(name string) string {
 		resource "vultr_instance" "test" {
 			plan = "vc2-1c-2gb"
 			region = "ewr"
-			os_id = 477
+			os_id = 167
 			label = "%s"
 			hostname = "testing-the-hostname"
 			enable_ipv6 = true
@@ -389,7 +389,7 @@ func testAccVultrInstanceBaseUpdateTags(name string) string {
 		resource "vultr_instance" "test" {
 			plan = "vc2-1c-2gb"
 			region = "sea"
-			os_id = 477
+			os_id = 167
 			label = "%s"
 			hostname = "testing-the-hostname"
 			enable_ipv6 = true


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Allow the ability to set the disable public IPv4 flag on create. I set it to optional & non-computed as this attribute/setting cannot be retrieved or modified after initial creation.

Additionally, the test for the instance was broken/incorrect so I fixed that.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Closes #383 to the best of my knowledge.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
Yes - only for the resource I touched. The larger set of tests failed due to unrelated issues.