### PR TITLE
Change `vultr_user.acl` to typeset as the ordering is not important and causes extraneous plans

### DIFF
--- a/vultr/resource_vultr_users.go
+++ b/vultr/resource_vultr_users.go
@@ -41,7 +41,7 @@ func resourceVultrUsers() *schema.Resource {
 				Default:  true,
 			},
 			"acl": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
@@ -64,7 +64,7 @@ func resourceVultrUsersCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	acl, aclOK := d.GetOk("acl")
-	a := acl.([]interface{})
+	a := acl.(*schema.Set).List()
 	var aclMap []string
 	if aclOK {
 		for _, v := range a {
@@ -138,7 +138,7 @@ func resourceVultrUsersUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	acl, aclOK := d.GetOk("acl")
-	a := acl.([]interface{})
+	a := acl.(*schema.Set).List()
 	var aclMap []string
 	if aclOK {
 		for _, v := range a {


### PR DESCRIPTION
## Description
This PR changes the `acl` property in the `vultr_user` resource from `TypeList` to `TypeSet`. The order of the ACLs is not important and due causes a lot of extraneous plans when the order of the ACLs do not match the order returned from the server.

## Related Issues
Closes #494

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
