### PR TITLE
Add `user_scheme` options for bare metal and instance

### DIFF
--- a/vultr/data_source_vultr_bare_metal_server.go
+++ b/vultr/data_source_vultr_bare_metal_server.go
@@ -104,6 +104,10 @@ func dataSourceVultrBareMetalServer() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"user_scheme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -218,6 +222,9 @@ func dataSourceVultrBareMetalServerRead(ctx context.Context, d *schema.ResourceD
 	}
 	if err := d.Set("features", serverList[0].Features); err != nil {
 		return diag.Errorf("unable to set bare_metal_server `features` read value: %v", err)
+	}
+	if err := d.Set("user_scheme", serverList[0].UserScheme); err != nil {
+		return diag.Errorf("unable to set bare_metal_server `user_scheme` read value: %v", err)
 	}
 
 	vpc2s, err := getBareMetalServerVPC2s(client, d.Id())

--- a/vultr/data_source_vultr_instance.go
+++ b/vultr/data_source_vultr_instance.go
@@ -107,6 +107,10 @@ func dataSourceVultrInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
+			"user_scheme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"os_id": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -313,6 +317,9 @@ func dataSourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	if err := d.Set("vpc2_ids", vpc2s); err != nil {
 		return diag.Errorf("unable to set instance `vpc2_ids` read value: %v", err)
+	}
+	if err := d.Set("user_scheme", serverList[0].UserScheme); err != nil {
+		return diag.Errorf("unable to set instance `user_scheme` read value: %v", err)
 	}
 
 	return nil

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -116,6 +116,10 @@ func dataSourceVultrInstances() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Computed: true,
 						},
+						"user_scheme": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"os_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -235,6 +239,7 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 					"v6_network_size":     server.V6NetworkSize,
 					"features":            server.Features,
 					"hostname":            server.Hostname,
+					"user_scheme":         server.UserScheme,
 					"backups":             backupStatus(schedule.Enabled),
 					"backups_schedule":    bsInfo,
 					"private_network_ids": vpcs,

--- a/website/docs/d/bare_metal_server.html.markdown
+++ b/website/docs/d/bare_metal_server.html.markdown
@@ -55,6 +55,7 @@ The following attributes are exported:
 * `label` - The server's label.
 * `tag` - The server's tag.
 * `tags` - A list of tags applied to the server.
+* `user_scheme` - The scheme used for the default user (linux servers only). 
 * `os_id` - The server's operating system ID.
 * `app_id` - The server's application ID.
 * `image_id` - The Marketplace ID for this application.

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -60,6 +60,7 @@ The following attributes are exported:
 * `kvm` - The server's current KVM URL. This URL will change periodically. It is not advised to cache this value.
 * `tag` - The server's tag.
 * `tags` - A list of tags applied to the instance.
+* `user_scheme` - The scheme used for the default user (linux servers only). 
 * `os_id` - The server's operating system ID.
 * `app_id` - The server's application ID.
 * `image_id` - The Marketplace ID for this application.

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -66,6 +66,7 @@ The following attributes are exported:
   * `kvm` - The server's current KVM URL. This URL will change periodically. It is not advised to cache this value.
   * `tag` - The server's tag.
   * `tags` - A list of tags applied to the instance.
+  * `user_scheme` - The scheme used for the default user (linux servers only). 
   * `os_id` - The server's operating system ID.
   * `app_id` - The server's application ID.
   * `image_id` - The Marketplace ID for this application.

--- a/website/docs/r/bare_metal_server.html.markdown
+++ b/website/docs/r/bare_metal_server.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 * `label` - (Optional) A label for the server.
 * `reserved_ipv4` - (Optional) The ID of the floating IP to use as the main IP of this server. [See Reserved IPs](https://www.vultr.com/api/#operation/list-reserved-ips)
 * `app_variables` - (Optional) A map of user-supplied variable keys and values for Vultr Marketplace apps. [See List Marketplace App Variables](https://www.vultr.com/api/#tag/marketplace/operation/list-marketplace-app-variables)
+* `user_scheme` - (Optional) The scheme used for the default user. Possible values are `root` or `limited` (linux servers only). 
 
 ## Attributes Reference
 
@@ -96,6 +97,7 @@ The following attributes are exported:
 * `tags` - A list of tags applied to the server.
 * `label` - A label for the server.
 * `mac_address` - The MAC address associated with the server.
+* `user_scheme` - The scheme used for the default user (linux servers only). 
 
 
 ## Import

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `hostname` - (Optional) The hostname to assign to the server.
 * `tag` - (Deprecated: use `tags` instead) (Optional) The tag to assign to the server.
 * `tags` - (Optional) A list of tags to apply to the instance.
+* `user_scheme` - (Optional) The scheme used for the default user. Possible values are `root` or `limited` (linux servers only). 
 * `label` - (Optional) A label for the server.
 * `reserved_ip_id` - (Optional) ID of the floating IP to use as the main IP of this server.
 * `app_variables` - (Optional) A map of user-supplied variable keys and values for Vultr Marketplace apps. [See List Marketplace App Variables](https://www.vultr.com/api/#tag/marketplace/operation/list-marketplace-app-variables)
@@ -128,6 +129,7 @@ The following attributes are exported:
 * `hostname` - The hostname assigned to the server.
 * `tag` - (Deprecated: use `tags` instead) The tag assigned to the server.
 * `tags` - A list of tags to apply to the instance.
+* `user_scheme` - The scheme used for the default user (linux servers only). 
 * `label` - A label for the server.
 * `features` - Array of which features are enabled.
 * `backups_schedule` - (Optional) A block that defines the way backups should be scheduled.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Exposes the API options for create/update to define the the `user_scheme` option for linux OS default user

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Resolves #469 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

### Test config
```hcl
resource "vultr_instance" "inst" {
  region = "mel"
  plan = "vc2-2c-4gb"
  label = "tf-user-test"
  os_id = 1743
  tags = ["tf-test"]
  user_scheme = "limited"
}

output "inst-update-scheme" {
  value = resource.vultr_instance.inst.user_scheme
}

data "vultr_instance" "inst-label" {
  filter {
    name = "label"
    values = [resource.vultr_instance.inst.label]
  }
}

output "inst-user-scheme" {
  value = data.vultr_instance.inst-label.user_scheme
}

data "vultr_instances" "insts" {
  filter {
    name = "label"
    values = [resource.vultr_instance.inst.label]
  }
}

output "insts-user-scheme" {
  value = data.vultr_instances.insts.instances[*].user_scheme
}

resource "vultr_bare_metal_server" "bm" {
  os_id = 1743
  plan = "vbm-6c-32gb"
  region = "mel"
  label = "tf-user-scheme-test"
  tags = ["tf", "test"]
  user_scheme = "limited"
}

output "bm-res-scheme" {
  value = resource.vultr_bare_metal_server.bm.user_scheme
}

data "vultr_bare_metal_server" "bm-label" {
  filter {
    name = "label"
    values = [resource.vultr_bare_metal_server.bm.label]
  }
}

output "bm-user-scheme" {
  value = data.vultr_bare_metal_server.bm-label.user_scheme
}
```
