### PR TITLE
Fix kubernetes enable_firewall always recreating cluster

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -236,7 +236,7 @@ You must set the default tag on one node pool before importing.`,
 	if err := d.Set("ha_controlplanes", vke.HAControlPlanes); err != nil {
 		return diag.Errorf("unable to set resource kubernetes `ha_controlplanes` read value: %v", err)
 	}
-	if err := d.Set("enable_firewall", nil); err != nil {
+	if err := d.Set("enable_firewall", vke.FirewallGroupID != ""); err != nil {
 		return diag.Errorf("unable to unset resource kubernetes `enable_firewall` read value: %v", err)
 	}
 	if err := d.Set("firewall_group_id", vke.FirewallGroupID); err != nil {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
We can use `FirewallGroupID` field from the API response to determine if the the firewall is enabled for the server.

## Related Issues
#529 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
