### PR TITLE
Remove the kubernetes set on enable_firewall

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -236,9 +236,6 @@ You must set the default tag on one node pool before importing.`,
 	if err := d.Set("ha_controlplanes", vke.HAControlPlanes); err != nil {
 		return diag.Errorf("unable to set resource kubernetes `ha_controlplanes` read value: %v", err)
 	}
-	if err := d.Set("enable_firewall", nil); err != nil {
-		return diag.Errorf("unable to unset resource kubernetes `enable_firewall` read value: %v", err)
-	}
 	if err := d.Set("firewall_group_id", vke.FirewallGroupID); err != nil {
 		return diag.Errorf("unable to set resource kubernetes `firewall_group_id` read value: %v", err)
 	}


### PR DESCRIPTION
This field is only present on the create route

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Remove the set value for `enable_firewall` on the kubernetes resource.  This value is not returned in the GET operation and should not be set in the read operation.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #529 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
