### PR TITLE
Deprecate Redis-Named Fields

### DIFF
--- a/vultr/database.go
+++ b/vultr/database.go
@@ -150,7 +150,7 @@ func readReplicaSchema(isReadReplica bool) map[string]*schema.Schema {
 			Computed: true,
 			Optional: true,
 		},
-		"redis_eviction_policy": {
+		"eviction_policy": {
 			Type:     schema.TypeString,
 			Computed: true,
 			Optional: true,
@@ -169,24 +169,24 @@ func readReplicaSchema(isReadReplica bool) map[string]*schema.Schema {
 	return s
 }
 
-func redisACLSchema() map[string]*schema.Schema {
+func userACLSchema() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
-		"redis_acl_categories": {
+		"acl_categories": {
 			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-		"redis_acl_channels": {
+		"acl_channels": {
 			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-		"redis_acl_commands": {
+		"acl_commands": {
 			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-		"redis_acl_keys": {
+		"acl_keys": {
 			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
@@ -196,13 +196,13 @@ func redisACLSchema() map[string]*schema.Schema {
 	return s
 }
 
-func flattenRedisACL(dbUser *govultr.DatabaseUser) []map[string]interface{} {
+func flattenUserACL(dbUser *govultr.DatabaseUser) []map[string]interface{} {
 	f := []map[string]interface{}{
 		{
-			"redis_acl_categories": dbUser.AccessControl.RedisACLCategories,
-			"redis_acl_channels":   dbUser.AccessControl.RedisACLChannels,
-			"redis_acl_commands":   dbUser.AccessControl.RedisACLCommands,
-			"redis_acl_keys":       dbUser.AccessControl.RedisACLKeys,
+			"acl_categories": dbUser.AccessControl.ACLCategories,
+			"acl_channels":   dbUser.AccessControl.ACLChannels,
+			"acl_commands":   dbUser.AccessControl.ACLCommands,
+			"acl_keys":       dbUser.AccessControl.ACLKeys,
 		},
 	}
 	return f

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -269,7 +269,7 @@ func resourceVultrDatabaseCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Default user (vultradmin) password can only be changed after creation
-	if password, passwordOK := d.GetOk("password"); passwordOK && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" {
+	if password, passwordOK := d.GetOk("password"); passwordOK && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" { //nolint:lll
 		req3 := &govultr.DatabaseUserUpdateReq{
 			Password: password.(string),
 		}
@@ -581,7 +581,7 @@ func resourceVultrDatabaseUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Updating the default user password requires a separate API call
-	if d.HasChange("password") && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" {
+	if d.HasChange("password") && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" { //nolint:lll
 		_, newVal := d.GetChange("password")
 		password := newVal.(string)
 		reqP := &govultr.DatabaseUserUpdateReq{

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -96,7 +96,7 @@ func resourceVultrDatabase() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
-			"redis_eviction_policy": {
+			"eviction_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -219,7 +219,7 @@ func resourceVultrDatabaseCreate(ctx context.Context, d *schema.ResourceData, me
 		MySQLRequirePrimaryKey: govultr.BoolToBoolPtr(true),
 		MySQLSlowQueryLog:      govultr.BoolToBoolPtr(false),
 		MySQLLongQueryTime:     d.Get("mysql_long_query_time").(int),
-		RedisEvictionPolicy:    d.Get("redis_eviction_policy").(string),
+		EvictionPolicy:         d.Get("eviction_policy").(string),
 	}
 
 	if trustedIPs, trustedIPsOK := d.GetOk("trusted_ips"); trustedIPsOK {
@@ -269,7 +269,7 @@ func resourceVultrDatabaseCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Default user (vultradmin) password can only be changed after creation
-	if password, passwordOK := d.GetOk("password"); passwordOK && d.Get("database_engine").(string) != "redis" {
+	if password, passwordOK := d.GetOk("password"); passwordOK && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" {
 		req3 := &govultr.DatabaseUserUpdateReq{
 			Password: password.(string),
 		}
@@ -304,7 +304,7 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("unable to set resource database `plan` read value: %v", err)
 	}
 
-	if database.DatabaseEngine != "redis" {
+	if database.DatabaseEngine != "redis" && database.DatabaseEngine != "valkey" {
 		if err := d.Set("plan_disk", database.PlanDisk); err != nil {
 			return diag.Errorf("unable to set resource database `plan_disk` read value: %v", err)
 		}
@@ -438,13 +438,13 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	if database.DatabaseEngine == "redis" {
-		if err := d.Set("redis_eviction_policy", database.RedisEvictionPolicy); err != nil {
-			return diag.Errorf("unable to set resource database `redis_eviction_policy` read value: %v", err)
+	if database.DatabaseEngine == "redis" || database.DatabaseEngine == "valkey" {
+		if err := d.Set("eviction_policy", database.EvictionPolicy); err != nil {
+			return diag.Errorf("unable to set resource database `eviction_policy` read value: %v", err)
 		}
 	}
 
-	if database.DatabaseEngine != "redis" {
+	if database.DatabaseEngine != "redis" && database.DatabaseEngine != "valkey" {
 		if err := d.Set("cluster_time_zone", database.ClusterTimeZone); err != nil {
 			return diag.Errorf("unable to set resource database `cluster_time_zone` read value: %v", err)
 		}
@@ -557,11 +557,11 @@ func resourceVultrDatabaseUpdate(ctx context.Context, d *schema.ResourceData, me
 		req.MySQLLongQueryTime = mysqlLongQueryTime
 	}
 
-	if d.HasChange("redis_eviction_policy") {
-		log.Printf("[INFO] Updating Redis Eviction Policy")
-		_, newVal := d.GetChange("redis_eviction_policy")
-		redisEvictionPolicy := newVal.(string)
-		req.RedisEvictionPolicy = redisEvictionPolicy
+	if d.HasChange("eviction_policy") {
+		log.Printf("[INFO] Updating Eviction Policy")
+		_, newVal := d.GetChange("eviction_policy")
+		evictionPolicy := newVal.(string)
+		req.EvictionPolicy = evictionPolicy
 	}
 
 	if _, _, err := client.Database.Update(ctx, d.Id(), req); err != nil {
@@ -581,7 +581,7 @@ func resourceVultrDatabaseUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Updating the default user password requires a separate API call
-	if d.HasChange("password") && d.Get("database_engine").(string) != "redis" {
+	if d.HasChange("password") && d.Get("database_engine").(string) != "redis" && d.Get("database_engine").(string) != "valkey" {
 		_, newVal := d.GetChange("password")
 		password := newVal.(string)
 		reqP := &govultr.DatabaseUserUpdateReq{

--- a/vultr/resource_vultr_database_replica.go
+++ b/vultr/resource_vultr_database_replica.go
@@ -102,7 +102,7 @@ func resourceVultrDatabaseReplicaRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("unable to set resource database read replica `plan` read value: %v", err)
 	}
 
-	if database.DatabaseEngine != "redis" {
+	if database.DatabaseEngine != "redis" && database.DatabaseEngine != "valkey" {
 		if err := d.Set("plan_disk", database.PlanDisk); err != nil {
 			return diag.Errorf("unable to set resource database read replica `plan_disk` read value: %v", err)
 		}
@@ -229,16 +229,16 @@ func resourceVultrDatabaseReplicaRead(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if database.DatabaseEngine == "redis" {
-		if err := d.Set("redis_eviction_policy", database.RedisEvictionPolicy); err != nil {
+	if database.DatabaseEngine == "redis" || database.DatabaseEngine == "valkey" {
+		if err := d.Set("eviction_policy", database.EvictionPolicy); err != nil {
 			return diag.Errorf(
-				"unable to set resource database read replica `redis_eviction_policy` read value: %v",
+				"unable to set resource database read replica `eviction_policy` read value: %v",
 				err,
 			)
 		}
 	}
 
-	if database.DatabaseEngine != "redis" {
+	if database.DatabaseEngine != "redis" && database.DatabaseEngine != "valkey" {
 		if err := d.Set("cluster_time_zone", database.ClusterTimeZone); err != nil {
 			return diag.Errorf("unable to set resource database read replica `cluster_time_zone` read value: %v", err)
 		}

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -69,6 +69,7 @@ The following attributes are exported:
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database (MySQL engine types only).
 * `mysql_long_query_time` - The configuration value for the long query time (in seconds) on the managed database (MySQL engine types only).
-* `redis_eviction_policy` - The configuration value for the data eviction policy on the managed database (Redis engine types only).
+* `redis_eviction_policy` - (Deprecated: use `eviction_policy` instead) The configuration value for the data eviction policy on the managed database (Redis engine types only).
+* `eviction_policy` - The configuration value for the data eviction policy on the managed database (Redis engine types only).
 * `cluster_time_zone` - The configured time zone for the Managed Database in TZ database format.
 * `read_replicas` - A list of read replicas attached to the managed database.

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -64,7 +64,8 @@ The following arguments are supported:
 * `mysql_require_primary_key` - (Optional) The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - (Optional) The configuration value for slow query logging on the managed database (MySQL engine types only).
 * `mysql_long_query_time` - (Optional) The configuration value for the long query time (in seconds) on the managed database (MySQL engine types only).
-* `redis_eviction_policy` - (Optional) The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+* `redis_eviction_policy` - (Deprecated: use `eviction_policy` instead) The configuration value for the data eviction policy on the managed database (Redis engine types only).
+* `eviction_policy` - (Optional) The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
 
 ## Attributes Reference
 
@@ -103,7 +104,8 @@ The following attributes are exported:
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database (MySQL engine types only).
 * `mysql_long_query_time` - The configuration value for the long query time (in seconds) on the managed database (MySQL engine types only).
-* `redis_eviction_policy` - The configuration value for the data eviction policy on the managed database (Redis engine types only).
+* `redis_eviction_policy` - (Deprecated: use `eviction_policy` instead) The configuration value for the data eviction policy on the managed database (Redis engine types only).
+* `eviction_policy` - The configuration value for the data eviction policy on the managed database (Redis engine types only).
 * `cluster_time_zone` - The configured time zone for the Managed Database in TZ database format.
 * `read_replicas` - A list of read replicas attached to the managed database.
 

--- a/website/docs/r/database_replica.html.markdown
+++ b/website/docs/r/database_replica.html.markdown
@@ -69,5 +69,6 @@ The following attributes are exported:
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database read replica (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database read replica (MySQL engine types only).
 * `mysql_long_query_time` - The configuration value for the long query time (in seconds) on the managed database read replica (MySQL engine types only).
-* `redis_eviction_policy` - The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+* `redis_eviction_policy` - (Deprecated: use `eviction_policy` instead) The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+* `eviction_policy` - The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
 * `cluster_time_zone` - The configured time zone for the managed database read replica in TZ database format.

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -54,7 +54,11 @@ The following attributes are exported:
 
 `access_control`
 
-* `redis_acl_categories` - List of command category rules for this managed database user (Redis engine types only).
-* `redis_acl_channels` - List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
-* `redis_acl_commands` - List of individual command rules for this managed database user (Redis engine types only).
-* `redis_acl_keys` - List of access rules for this managed database user (Redis engine types only).
+* `redis_acl_categories` - (Deprecated: use `acl_categories` instead) List of command category rules for this managed database user (Redis engine types only).
+* `redis_acl_channels` - (Deprecated: use `acl_channels` instead) List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+* `redis_acl_commands` - (Deprecated: use `acl_commands` instead) List of individual command rules for this managed database user (Redis engine types only).
+* `redis_acl_keys` - (Deprecated: use `acl_keys` instead) List of access rules for this managed database user (Redis engine types only).
+* `acl_categories` - List of command category rules for this managed database user (Redis engine types only).
+* `acl_channels` - List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+* `acl_commands` - List of individual command rules for this managed database user (Redis engine types only).
+* `acl_keys` - List of access rules for this managed database user (Redis engine types only).


### PR DESCRIPTION
## Description
This PR brings the Terraform provider up to date with recent Govultr changes removing Redis-named fields and properties to replace them with generic versions. This is for future support of other caching engine types.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
