### PR TITLE
Add default timeout for snapshot create

### DIFF
--- a/vultr/resource_vultr_snapshot.go
+++ b/vultr/resource_vultr_snapshot.go
@@ -56,7 +56,7 @@ func resourceVultrSnapshot() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute), //nolint:mnd
 		},
 	}
 }

--- a/vultr/resource_vultr_snapshot.go
+++ b/vultr/resource_vultr_snapshot.go
@@ -55,6 +55,9 @@ func resourceVultrSnapshot() *schema.Resource {
 				Computed: true,
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
 	}
 }
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -34,6 +34,23 @@ The following arguments are supported:
 * `instance_id` - (Required) ID of a given instance that you want to create a snapshot from.
 * `description` - (Optional) The description for the given snapshot.
 
+Snapshots often exceed the default timeout built in to all create requests in
+the provider. In order to customize that, you may specify a custome value in a
+`timeouts` block of the resource definition
+
+* `timeouts` - (Optional) The create timeout value can be manually set
+
+``` hcl
+resource "vultr_snapshot" "sn" {
+  instance_id = resource.vultr_instance.test-inst.id
+  description = "terraform timeout test"
+
+  timeouts {
+    create = "60m"
+  }
+}
+```
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Add a default timeout on the create for snapshot resources.  This allows using a timeouts block to set a custom value, ie:
``` hcl
resource "vultr_snapshot" "sn" {
  instance_id = resource.vultr_instance.inst.id
  description = "terraform timeout test"

  timeouts {
    create = "60m"
  }
}
```

This will also increase the default from 20 minutes to 30 minutes without need for customization.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Resolves #509

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
