### PR TITLE
respect vpc2 order for resource_vultr_instance

### DIFF
--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -72,7 +72,7 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				ForceNew: true,
 			},
 			"vpc2_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -264,7 +264,7 @@ func resourceVultrBareMetalServerCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if vpcIDs, vpcOK := d.GetOk("vpc2_ids"); vpcOK {
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			req.AttachVPC2 = append(req.AttachVPC2, v.(string))
 		}
 	}
@@ -411,12 +411,12 @@ func resourceVultrBareMetalServerUpdate(ctx context.Context, d *schema.ResourceD
 		oldVPC, newVPC := d.GetChange("vpc2_ids")
 
 		var oldIDs []string
-		for _, v := range oldVPC.(*schema.Set).List() {
+		for _, v := range oldVPC.([]interface{}) {
 			oldIDs = append(oldIDs, v.(string))
 		}
 
 		var newIDs []string
-		for _, v := range newVPC.(*schema.Set).List() {
+		for _, v := range newVPC.([]interface{}) {
 			newIDs = append(newIDs, v.(string))
 		}
 
@@ -449,7 +449,7 @@ func resourceVultrBareMetalServerDelete(ctx context.Context, d *schema.ResourceD
 
 	if vpcIDs, vpcOK := d.GetOk("vpc2_ids"); vpcOK {
 		detach := &govultr.BareMetalUpdate{}
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			detach.DetachVPC2 = append(detach.DetachVPC2, v.(string))
 		}
 

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -80,13 +80,13 @@ func resourceVultrInstance() *schema.Resource {
 Will not do anything unless enable_ipv6 is also true.`,
 			},
 			"vpc_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"vpc2_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -369,13 +369,13 @@ func resourceVultrInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if vpcIDs, vpcOK := d.GetOk("vpc_ids"); vpcOK {
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			req.AttachVPC = append(req.AttachVPC, v.(string))
 		}
 	}
 
 	if vpcIDs, vpcOK := d.GetOk("vpc2_ids"); vpcOK {
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			req.AttachVPC2 = append(req.AttachVPC2, v.(string))
 		}
 	}
@@ -620,12 +620,12 @@ func resourceVultrInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		oldVPC, newVPC := d.GetChange("vpc_ids")
 
 		var oldIDs []string
-		for _, v := range oldVPC.(*schema.Set).List() {
+		for _, v := range oldVPC.([]interface{}) {
 			oldIDs = append(oldIDs, v.(string))
 		}
 
 		var newIDs []string
-		for _, v := range newVPC.(*schema.Set).List() {
+		for _, v := range newVPC.([]interface{}) {
 			newIDs = append(newIDs, v.(string))
 		}
 
@@ -638,12 +638,12 @@ func resourceVultrInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		oldVPC, newVPC := d.GetChange("vpc2_ids")
 
 		var oldIDs []string
-		for _, v := range oldVPC.(*schema.Set).List() {
+		for _, v := range oldVPC.([]interface{}) {
 			oldIDs = append(oldIDs, v.(string))
 		}
 
 		var newIDs []string
-		for _, v := range newVPC.(*schema.Set).List() {
+		for _, v := range newVPC.([]interface{}) {
 			newIDs = append(newIDs, v.(string))
 		}
 
@@ -713,7 +713,7 @@ func resourceVultrInstanceDelete(ctx context.Context, d *schema.ResourceData, me
 
 	if vpcIDs, vpcOK := d.GetOk("vpc_ids"); vpcOK {
 		detach := &govultr.InstanceUpdateReq{}
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			detach.DetachVPC = append(detach.DetachVPC, v.(string))
 		}
 
@@ -724,7 +724,7 @@ func resourceVultrInstanceDelete(ctx context.Context, d *schema.ResourceData, me
 
 	if vpcIDs, vpcOK := d.GetOk("vpc2_ids"); vpcOK {
 		detach := &govultr.InstanceUpdateReq{}
-		for _, v := range vpcIDs.(*schema.Set).List() {
+		for _, v := range vpcIDs.([]interface{}) {
 			detach.DetachVPC2 = append(detach.DetachVPC2, v.(string))
 		}
 


### PR DESCRIPTION
## Description

The vpc2_ids were stored in a set type, so the order wasn't preserved. I changed it to a list type.

***NOTE: This is an incomplete change. A check for duplicate values should be added. ~~This change should be done to other resources like bare metal.~~***

***NOTE: I am not a Go programmer.***

***NOTE: I am not doing anymore with this PR. You can merge it, or close it.***

## Related Issues

Fixes #550

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
