### PR TITLE
Add object storage tier param and data source

### DIFF
--- a/vultr/data_source_vultr_object_storage_tier.go
+++ b/vultr/data_source_vultr_object_storage_tier.go
@@ -1,0 +1,131 @@
+package vultr
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vultr/govultr/v3"
+)
+
+func dataSourceVultrObjectStorageTier() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVultrObjectStorageTierRead,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"price": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"locations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"slug": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rate_limit_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rate_limit_operations": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVultrObjectStorageTierRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint:lll
+	client := meta.(*Client).govultrClient()
+
+	filters, filtersOk := d.GetOk("filter")
+	if !filtersOk {
+		return diag.Errorf("issue with filter: %v", filtersOk)
+	}
+
+	tierList := []govultr.ObjectStorageTier{}
+	f := buildVultrDataSourceFilter(filters.(*schema.Set))
+
+	tiers, _, err := client.ObjectStorage.ListTiers(ctx)
+	if err != nil {
+		return diag.Errorf("Error getting object storage tier list : %v", err)
+	}
+
+	for i := range tiers {
+		sm, err := structToMap(tiers[i])
+
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if filterLoop(f, sm) {
+			tierList = append(tierList, tiers[i])
+		}
+	}
+
+	if len(tierList) > 1 {
+		return diag.Errorf(`your object storage tier search returned too many results. 
+Please refine your search to be more specific`)
+	}
+
+	if len(tierList) < 1 {
+		return diag.Errorf("no object storage tier results were found")
+	}
+
+	d.SetId(strconv.Itoa(tierList[0].ID))
+	if err := d.Set("price", tierList[0].Price); err != nil {
+		return diag.Errorf("unable to set object storage tier `price` read value: %v", err)
+	}
+	if err := d.Set("slug", tierList[0].Slug); err != nil {
+		return diag.Errorf("unable to set object storage tier `slug` read value: %v", err)
+	}
+	if err := d.Set("rate_limit_bytes", tierList[0].RateLimitBytesSec); err != nil {
+		return diag.Errorf("unable to set object storage tier `rate_limit_bytes` read value: %v", err)
+	}
+	if err := d.Set("rate_limit_operations", tierList[0].RateLimitOpsSec); err != nil {
+		return diag.Errorf("unable to set object storage tier `rate_limit_operations` read value: %v", err)
+	}
+
+	var tierLocs []map[string]interface{}
+	for j := range tierList[0].Locations {
+		tierLocs = append(tierLocs, map[string]interface{}{
+			"id":       tierList[0].Locations[j].ID,
+			"region":   tierList[0].Locations[j].Region,
+			"hostname": tierList[0].Locations[j].Hostname,
+			"name":     tierList[0].Locations[j].Name,
+		})
+	}
+
+	if err := d.Set("locations", tierLocs); err != nil {
+		return diag.Errorf("unable to set object storage tier `locations` read value: %v", err)
+	}
+
+	return nil
+}

--- a/vultr/data_source_vultr_object_storage_tier_test.go
+++ b/vultr/data_source_vultr_object_storage_tier_test.go
@@ -1,0 +1,39 @@
+package vultr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVultrObjectStorageTier(t *testing.T) {
+	t.Parallel()
+	name := "data.vultr_object_storage_tier.obs_tier"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVultrObjectStorageTier(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "id"),
+					resource.TestCheckResourceAttrSet(name, "price"),
+					resource.TestCheckResourceAttrSet(name, "locations.#"),
+					resource.TestCheckResourceAttrSet(name, "slug"),
+					resource.TestCheckResourceAttrSet(name, "rate_limit_bytes"),
+					resource.TestCheckResourceAttrSet(name, "rate_limit_operations"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVultrObjectStorageTier() string {
+	return `
+		data "vultr_object_storage_tier" "obs_tier" {
+			filter {
+				name = "id"
+				values = ["4"]
+			}
+		}`
+}

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -44,6 +44,7 @@ func Provider() *schema.Provider {
 			"vultr_load_balancer":          dataSourceVultrLoadBalancer(),
 			"vultr_object_storage":         dataSourceVultrObjectStorage(),
 			"vultr_object_storage_cluster": dataSourceVultrObjectStorageClusters(),
+			"vultr_object_storage_tier":    dataSourceVultrObjectStorageTier(),
 			"vultr_os":                     dataSourceVultrOS(),
 			"vultr_plan":                   dataSourceVultrPlan(),
 			"vultr_region":                 dataSourceVultrRegion(),

--- a/vultr/resource_vultr_object_storage.go
+++ b/vultr/resource_vultr_object_storage.go
@@ -27,6 +27,11 @@ func resourceVultrObjectStorage() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"tier_id": {
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Required: true,
+			},
 			"label": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -69,10 +74,12 @@ func resourceVultrObjectStorage() *schema.Resource {
 func resourceVultrObjectStorageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Client).govultrClient()
 
-	objStoreCluster := d.Get("cluster_id").(int)
-	label := d.Get("label").(string)
+	objReq := &govultr.ObjectStorageReq{
+		ClusterID: d.Get("cluster_id").(int),
+		TierID:    d.Get("tier_id").(int),
+		Label:     d.Get("label").(string),
+	}
 
-	objReq := &govultr.ObjectStorageReq{ClusterID: objStoreCluster, Label: label}
 	obj, _, err := client.ObjectStorage.Create(ctx, objReq)
 	if err != nil {
 		return diag.Errorf("error creating object storage: %v", err)

--- a/vultr/resource_vultr_object_storage_test.go
+++ b/vultr/resource_vultr_object_storage_test.go
@@ -58,7 +58,8 @@ func TestAccVultrObjectStorageUpdateLabel(t *testing.T) {
 func testAccVultrObjectStorageBase(label string) string {
 	return fmt.Sprintf(`
 		resource "vultr_object_storage" "test" {
-			cluster_id = 2
+			cluster_id = 9
+			tier_id = 5
 			label = "%s"
 		}`, label)
 }
@@ -66,7 +67,8 @@ func testAccVultrObjectStorageBase(label string) string {
 func testAccVultrObjectStorageUpdated(label string) string {
 	return fmt.Sprintf(`
 		resource "vultr_object_storage" "test" {
-			cluster_id = 2
+			cluster_id = 9
+			tier_id = 5
 			label = "%s"
 		}`, label)
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* Add the `tier_id` param to `vultr_object_storage` resources
```terraform
resource "vultr_object_storage" "vobs" {
  cluster_id = 9
  tier_id = 5
  label = "tf-test-upd"
}
```
* Add a data source to query tiers `vultr_object_storage_tier`
```terraform
data "vultr_object_storage_tier" "obs-tier" {
  filter {
    name = "slug"
    values = ["tier_010k_5000m"]
  }
}
```

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Resolves #556 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
