### PR TITLE
Add labels to kubernetes node pools

### DIFF
--- a/vultr/data_source_vultr_kubernetes.go
+++ b/vultr/data_source_vultr_kubernetes.go
@@ -227,6 +227,7 @@ func flattenNodePools(np []govultr.NodePool) []map[string]interface{} {
 			"min_nodes":     n.MinNodes,
 			"max_nodes":     n.MaxNodes,
 			"nodes":         instances,
+			"labels":        n.Labels,
 		}
 
 		nodePools = append(nodePools, pool)

--- a/vultr/vke.go
+++ b/vultr/vke.go
@@ -57,6 +57,13 @@ func nodePoolSchema(isNodePool bool) map[string]*schema.Schema {
 			Optional: true,
 			Default:  1,
 		},
+		"labels": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		//computed fields
 		"id": {
 			Type:     schema.TypeString,

--- a/website/docs/d/kubernetes.html.markdown
+++ b/website/docs/d/kubernetes.html.markdown
@@ -69,6 +69,7 @@ The following attributes are exported:
 * `auto_scaler` - Boolean indicating if the auto scaler for the default node pool is active.
 * `min_nodes` - The minimum number of nodes used by the auto scaler.
 * `max_nodes` - The maximum number of nodes used by the auto scaler.
+* `labels` - Kubernetes node labels applied to the node pool.
 
 `nodes`
 

--- a/website/docs/r/kubernetes_node_pools.html.markdown
+++ b/website/docs/r/kubernetes_node_pools.html.markdown
@@ -21,9 +21,14 @@ resource "vultr_kubernetes_node_pools" "np-1" {
     plan = "vc2-2c-4gb"
     label = "my-label"
     tag = "my-tag"
-	auto_scaler = true
-	min_nodes = 1
-	max_nodes = 2
+    auto_scaler = true
+    min_nodes = 1
+    max_nodes = 2
+
+    labels = {
+	my-label = "a-label-on-all-nodes",
+	my-second-label = "another-label-on-all-nodes"
+    }
 }
 
 ```
@@ -40,9 +45,7 @@ The follow arguments are supported:
 * `auto_scaler` - (Optional) Enable the auto scaler for the default node pool.
 * `min_nodes` - (Optional) The minimum number of nodes to use with the auto scaler.
 * `max_nodes` - (Optional) The maximum number of nodes to use with the auto scaler.
-* `labels` - (Optional) Key/value pairs for Kubernetes node labels.
-
-
+* `labels` - (Optional) A map of key/value pairs for Kubernetes node labels.
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_node_pools.html.markdown
+++ b/website/docs/r/kubernetes_node_pools.html.markdown
@@ -40,6 +40,7 @@ The follow arguments are supported:
 * `auto_scaler` - (Optional) Enable the auto scaler for the default node pool.
 * `min_nodes` - (Optional) The minimum number of nodes to use with the auto scaler.
 * `max_nodes` - (Optional) The maximum number of nodes to use with the auto scaler.
+* `labels` - (Optional) Key/value pairs for Kubernetes node labels.
 
 
 
@@ -59,6 +60,7 @@ The following attributes are exported:
 * `auto_scaler` - Boolean indicating if the  auto scaler for the default node pool is active.
 * `min_nodes` - The minimum number of nodes used by the auto scaler.
 * `max_nodes` - The maximum number of nodes used by the auto scaler.
+* `labels` - Key/value pairs for Kubernetes node labels.
 
 `nodes`
 
@@ -77,5 +79,3 @@ look like this:
 
 ```sh
 # "clusterID nodePoolID"
-terraform import vultr_kubernetes_node_pools.my-k8s-np "7365a98b-5a43-450f-bd27-d768827100e5 ec330340-4f50-4526-858f-a39199f568ac"
-```

--- a/website/docs/r/kubernetes_node_pools.html.markdown
+++ b/website/docs/r/kubernetes_node_pools.html.markdown
@@ -79,3 +79,5 @@ look like this:
 
 ```sh
 # "clusterID nodePoolID"
+terraform import vultr_kubernetes_node_pools.my-k8s-np "7365a98b-5a43-450f-bd27-d768827100e5 ec330340-4f50-4526-858f-a39199f568ac"
+```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* Adds labels field to kubernetes node pool resource
* Adds labels to kubernetes data source

```hcl
resource "vultr_kubernetes" "vke" {
    region  = "yto"
    label   = "tf-vpc-test"
    version = "v1.32.2+1"

    node_pools {
        node_quantity = 3
        plan          = "vc2-4c-8gb"
        label         = "tf-vpc-def-np"
    }
} 

resource "vultr_kubernetes_node_pools" "vke-np" {
  cluster_id = vultr_kubernetes.vke.id
  node_quantity = 4
  plan          = "vc2-4c-8gb"
  label         = "tf-vpc-test-np"

  labels = {
    label-test = "testing-testing-testing",
    another-test = "test-test-test"
  }
}

data "vultr_kubernetes" "vke-data" {
  filter {
    name = "label"
    values = [resource.vultr_kubernetes.vke.label]
  }
}

output "vke-labels-output" {
  value = data.vultr_kubernetes.vke-data.node_pools
}
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
