### PR TITLE
Fix default node pool labels on kubernetes resource

### DIFF
--- a/website/docs/r/kubernetes.html.markdown
+++ b/website/docs/r/kubernetes.html.markdown
@@ -29,8 +29,12 @@ resource "vultr_kubernetes" "k8" {
 		auto_scaler   = true
 		min_nodes     = 1
 		max_nodes     = 2
+		labels = {
+			my-label = "a-label-on-all-nodes"
+			my-second-label = "another-label-on-all-nodes"
+		}
 	}
-} 
+}
 ```
 
 A default node pool is required when first creating the resource but it can be removed at a later point so long as there is a separate `vultr_kubernetes_node_pools` resource attached. For example:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The labels for the default node pool are handled a bit differently and were not correctly implemented before.  This allows defining and updating on the default kubernetes resource node pool block and updates the documentation to reflect this.
```hcl
resource "vultr_kubernetes" "vke" {
    region  = "yto"
    label   = "tf-labels-test"
    version = "v1.32.2+1"

    node_pools {
        node_quantity = 3
        plan          = "vc2-4c-8gb"
        label         = "tf-vpc-def-np"

        labels = {
          label-test = "testing-te"
          label-test-2 = "testing-t"
        }
    }
} 
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
