### PR TITLE
Managed Databases: Add Expanded Support for Kafka Features

### DIFF
--- a/vultr/data_source_vultr_database.go
+++ b/vultr/data_source_vultr_database.go
@@ -111,6 +111,26 @@ func dataSourceVultrDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"enable_kafka_rest": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"kafka_rest_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_schema_registry": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"schema_registry_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_kafka_connect": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"maintenance_dow": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -317,6 +337,26 @@ func dataSourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 
 		if err := d.Set("access_cert", databaseList[0].AccessCert); err != nil {
 			return diag.Errorf("unable to set resource database `access_cert` read value: %v", err)
+		}
+
+		if err := d.Set("enable_kafka_rest", databaseList[0].EnableKafkaREST); err != nil {
+			return diag.Errorf("unable to set resource database `enable_kafka_rest` read value: %v", err)
+		}
+
+		if err := d.Set("kafka_rest_uri", databaseList[0].KafkaRESTURI); err != nil {
+			return diag.Errorf("unable to set resource database `kafka_rest_uri` read value: %v", err)
+		}
+
+		if err := d.Set("enable_schema_registry", databaseList[0].EnableSchemaRegistry); err != nil {
+			return diag.Errorf("unable to set resource database `enable_schema_registry` read value: %v", err)
+		}
+
+		if err := d.Set("schema_registry_uri", databaseList[0].SchemaRegistryURI); err != nil {
+			return diag.Errorf("unable to set resource database `schema_registry_uri` read value: %v", err)
+		}
+
+		if err := d.Set("enable_kafka_connect", databaseList[0].EnableKafkaConnect); err != nil {
+			return diag.Errorf("unable to set resource database `enable_kafka_connect` read value: %v", err)
 		}
 	}
 

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -74,6 +74,7 @@ func Provider() *schema.Provider {
 			"vultr_database_user":               resourceVultrDatabaseUser(),
 			"vultr_database_topic":              resourceVultrDatabaseTopic(),
 			"vultr_database_quota":              resourceVultrDatabaseQuota(),
+			"vultr_database_connector":          resourceVultrDatabaseConnector(),
 			"vultr_dns_domain":                  resourceVultrDNSDomain(),
 			"vultr_dns_record":                  resourceVultrDNSRecord(),
 			"vultr_firewall_group":              resourceVultrFirewallGroup(),

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -469,7 +469,7 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 			return diag.Errorf("unable to set resource database `enable_kafka_rest` read value: %v", err)
 		}
 
-		if err := d.Set("kafka_rest_uri", database.AccessCert); err != nil {
+		if err := d.Set("kafka_rest_uri", database.KafkaRESTURI); err != nil {
 			return diag.Errorf("unable to set resource database `kafka_rest_uri` read value: %v", err)
 		}
 
@@ -477,7 +477,7 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 			return diag.Errorf("unable to set resource database `enable_schema_registry` read value: %v", err)
 		}
 
-		if err := d.Set("schema_registry_uri", database.AccessCert); err != nil {
+		if err := d.Set("schema_registry_uri", database.SchemaRegistryURI); err != nil {
 			return diag.Errorf("unable to set resource database `schema_registry_uri` read value: %v", err)
 		}
 

--- a/vultr/resource_vultr_database_connector.go
+++ b/vultr/resource_vultr_database_connector.go
@@ -65,8 +65,8 @@ func resourceVultrDatabaseConnectorCreate(ctx context.Context, d *schema.Resourc
 
 	req := &govultr.DatabaseConnectorCreateReq{
 		Name:   d.Get("name").(string),
-		Class:  d.Get("partitions").(string),
-		Topics: d.Get("replication").(string),
+		Class:  d.Get("class").(string),
+		Topics: d.Get("topics").(string),
 		Config: configMap,
 	}
 
@@ -103,7 +103,16 @@ func resourceVultrDatabaseConnectorRead(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("unable to set resource database connector `topics` read value: %v", err)
 	}
 
-	// handle config json to map
+	if databaseConnector.Config != nil {
+		jsonBytes, err := json.Marshal(databaseConnector.Config)
+		if err != nil {
+			return diag.Errorf("error serializing field `config` to JSON: %v", err)
+		}
+
+		if err := d.Set("config", string(jsonBytes)); err != nil {
+			return diag.Errorf("unable to set resource database connector `config` read value: %v", err)
+		}
+	}
 
 	return nil
 }

--- a/vultr/resource_vultr_database_connector.go
+++ b/vultr/resource_vultr_database_connector.go
@@ -50,7 +50,7 @@ func resourceVultrDatabaseConnector() *schema.Resource {
 	}
 }
 
-func resourceVultrDatabaseConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVultrDatabaseConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint:lll
 	client := meta.(*Client).govultrClient()
 
 	databaseID := d.Get("database_id").(string)
@@ -81,7 +81,7 @@ func resourceVultrDatabaseConnectorCreate(ctx context.Context, d *schema.Resourc
 	return resourceVultrDatabaseConnectorRead(ctx, d, meta)
 }
 
-func resourceVultrDatabaseConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVultrDatabaseConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint:lll
 	client := meta.(*Client).govultrClient()
 
 	databaseID := d.Get("database_id").(string)
@@ -117,7 +117,7 @@ func resourceVultrDatabaseConnectorRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceVultrDatabaseConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVultrDatabaseConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint:lll
 	client := meta.(*Client).govultrClient()
 
 	databaseID := d.Get("database_id").(string)
@@ -137,7 +137,7 @@ func resourceVultrDatabaseConnectorUpdate(ctx context.Context, d *schema.Resourc
 		var configMap map[string]interface{}
 		if config != "" {
 			if err := json.Unmarshal([]byte(config), &configMap); err != nil {
-				return diag.Errorf("error parsing JSON for field `config` for updating database connector %s : %s", d.Id(), err.Error())
+				return diag.Errorf("error parsing JSON for field `config` for updating database connector %s : %s", d.Id(), err.Error()) //nolint:lll
 			}
 		}
 
@@ -151,7 +151,7 @@ func resourceVultrDatabaseConnectorUpdate(ctx context.Context, d *schema.Resourc
 	return resourceVultrDatabaseConnectorRead(ctx, d, meta)
 }
 
-func resourceVultrDatabaseConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVultrDatabaseConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint:lll
 	client := meta.(*Client).govultrClient()
 	log.Printf("[INFO] Deleting database connector (%s)", d.Id())
 

--- a/vultr/resource_vultr_database_connector.go
+++ b/vultr/resource_vultr_database_connector.go
@@ -1,0 +1,156 @@
+package vultr
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vultr/govultr/v3"
+)
+
+func resourceVultrDatabaseConnector() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVultrDatabaseConnectorCreate,
+		ReadContext:   resourceVultrDatabaseConnectorRead,
+		UpdateContext: resourceVultrDatabaseConnectorUpdate,
+		DeleteContext: resourceVultrDatabaseConnectorDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required
+			"database_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+				ForceNew:     true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"class": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"topics": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"config": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceVultrDatabaseConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+
+	databaseID := d.Get("database_id").(string)
+	config := d.Get("config").(string)
+
+	var configMap map[string]interface{}
+	if config != "" {
+		if err := json.Unmarshal([]byte(config), &configMap); err != nil {
+			return diag.Errorf("error parsing JSON for field `config` for database connector create: %v", err)
+		}
+	}
+
+	req := &govultr.DatabaseConnectorCreateReq{
+		Name:   d.Get("name").(string),
+		Class:  d.Get("partitions").(string),
+		Topics: d.Get("replication").(string),
+		Config: configMap,
+	}
+
+	log.Printf("[INFO] Creating database connector")
+	databaseConnector, _, err := client.Database.CreateConnector(ctx, databaseID, req)
+	if err != nil {
+		return diag.Errorf("error creating database connector: %v", err)
+	}
+
+	d.SetId(databaseConnector.Name)
+
+	return resourceVultrDatabaseConnectorRead(ctx, d, meta)
+}
+
+func resourceVultrDatabaseConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+
+	databaseID := d.Get("database_id").(string)
+
+	databaseConnector, _, err := client.Database.GetConnector(ctx, databaseID, d.Id())
+	if err != nil {
+		return diag.Errorf("error getting database connector (%s): %v", d.Id(), err)
+	}
+
+	if err := d.Set("name", databaseConnector.Name); err != nil {
+		return diag.Errorf("unable to set resource database connector `name` read value: %v", err)
+	}
+
+	if err := d.Set("class", databaseConnector.Class); err != nil {
+		return diag.Errorf("unable to set resource database connector `class` read value: %v", err)
+	}
+
+	if err := d.Set("topics", databaseConnector.Topics); err != nil {
+		return diag.Errorf("unable to set resource database connector `topics` read value: %v", err)
+	}
+
+	// handle config json to map
+
+	return nil
+}
+
+func resourceVultrDatabaseConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+
+	databaseID := d.Get("database_id").(string)
+
+	req := &govultr.DatabaseConnectorUpdateReq{}
+	log.Printf("[INFO] Updating database connector (%s)", d.Id())
+
+	if d.HasChange("topics") {
+		log.Print("[INFO] Updating `topics`")
+		req.Topics = d.Get("topics").(string)
+	}
+
+	if d.HasChange("config") {
+		log.Print("[INFO] Updating `config`")
+		config := d.Get("config").(string)
+
+		var configMap map[string]interface{}
+		if config != "" {
+			if err := json.Unmarshal([]byte(config), &configMap); err != nil {
+				return diag.Errorf("error parsing JSON for field `config` for updating database connector %s : %s", d.Id(), err.Error())
+			}
+		}
+
+		req.Config = configMap
+	}
+
+	if _, _, err := client.Database.UpdateConnector(ctx, databaseID, d.Id(), req); err != nil {
+		return diag.Errorf("error updating database connector %s : %s", d.Id(), err.Error())
+	}
+
+	return resourceVultrDatabaseConnectorRead(ctx, d, meta)
+}
+
+func resourceVultrDatabaseConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+	log.Printf("[INFO] Deleting database connector (%s)", d.Id())
+
+	databaseID := d.Get("database_id").(string)
+
+	if err := client.Database.DeleteConnector(ctx, databaseID, d.Id()); err != nil {
+		return diag.Errorf("error destroying database connector %s : %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/vultr/resource_vultr_database_connector_test.go
+++ b/vultr/resource_vultr_database_connector_test.go
@@ -1,0 +1,121 @@
+package vultr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccVultrDatabaseConnectorBasic(t *testing.T) {
+	t.Parallel()
+	pName := acctest.RandomWithPrefix("tf-db-rs")
+	rName := acctest.RandomWithPrefix("tf-db-connector")
+
+	name := "vultr_database_connector.test_connector"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckVultrDatabaseConnectorDestroy,
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVultrDatabaseKafkaBase(pName) + testAccVultrDatabaseConnectorBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rName),
+					resource.TestCheckResourceAttr(name, "class", "com.couchbase.connect.kafka.CouchbaseSinkConnector"),
+					resource.TestCheckResourceAttr(name, "topics", "tf-db-topic"),
+					resource.TestCheckResourceAttr(name, "config", "{\"couchbase.seed.nodes\":\"3\",\"couchbase.username\":\"some_username\",\"couchbase.password\":\"some_password\"}"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVultrDatabaseConnectorUpdate(t *testing.T) {
+	t.Parallel()
+	pName := acctest.RandomWithPrefix("tf-db-rs")
+	rName := acctest.RandomWithPrefix("tf-db-connector-up")
+
+	name := "vultr_database_connector.test_connector"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckVultrDatabaseConnectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVultrDatabaseKafkaBase(pName) + testAccVultrDatabaseConnectorBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rName),
+					resource.TestCheckResourceAttr(name, "class", "com.couchbase.connect.kafka.CouchbaseSinkConnector"),
+					resource.TestCheckResourceAttr(name, "topics", "tf-db-topic"),
+					resource.TestCheckResourceAttr(name, "config", "{\"couchbase.seed.nodes\":\"3\",\"couchbase.username\":\"some_username\",\"couchbase.password\":\"some_password\"}"),
+				),
+			},
+			{
+				PreConfig: func() { time.Sleep(60 * time.Second) },
+				Config:    testAccVultrDatabaseKafkaBase(pName) + testAccVultrDatabaseConnectorBaseUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", rName),
+					resource.TestCheckResourceAttr(name, "class", "com.couchbase.connect.kafka.CouchbaseSinkConnector"),
+					resource.TestCheckResourceAttr(name, "topics", "tf-db-topic-2"),
+					resource.TestCheckResourceAttr(name, "config", "{\"couchbase.seed.nodes\":\"3\",\"couchbase.username\":\"some_username\",\"couchbase.password\":\"some_password\"}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVultrDatabaseConnectorDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vultr_database_connector" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Client).govultrClient()
+		_, _, err := client.Database.GetConnector(context.Background(), rs.Primary.Attributes["database_id"], rs.Primary.ID)
+		if err != nil {
+			if strings.Contains(err.Error(), "Not a valid database connector") || strings.Contains(err.Error(), "Not a valid Database Subscription UUID") {
+				return nil
+			}
+			return fmt.Errorf("error getting database connector: %s", err)
+		}
+
+		return fmt.Errorf("database connector %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccVultrDatabaseConnectorBase(name string) string {
+	return fmt.Sprintf(`
+		resource "vultr_database_connector" "test_connector" {
+			database_id = vultr_database.test.id
+			name = "%s"
+			class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"
+			topics = "tf-db-topic"
+			config = jsonencode({
+				"couchbase.seed.nodes" = "3"
+				"couchbase.username" = "some_username"
+				"couchbase.password" = "some_password"
+			})
+		} `, name)
+}
+
+func testAccVultrDatabaseConnectorBaseUpdated(name string) string {
+	return fmt.Sprintf(`
+		resource "vultr_database_connector" "test_connector" {
+			database_id = vultr_database.test.id
+			name = "%s"
+			class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"
+			topics = "tf-db-topic-2"
+			config = jsonencode({
+				"couchbase.seed.nodes" = "3"
+				"couchbase.username" = "some_username"
+				"couchbase.password" = "some_password"
+			})
+		} `, name)
+}

--- a/vultr/resource_vultr_database_quota.go
+++ b/vultr/resource_vultr_database_quota.go
@@ -16,6 +16,7 @@ func resourceVultrDatabaseQuota() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceVultrDatabaseQuotaCreate,
 		ReadContext:   resourceVultrDatabaseQuotaRead,
+		UpdateContext: resourceVultrDatabaseQuotaUpdate,
 		DeleteContext: resourceVultrDatabaseQuotaDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -130,6 +131,37 @@ func resourceVultrDatabaseQuotaRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	return nil
+}
+
+func resourceVultrDatabaseQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client).govultrClient()
+
+	databaseID := d.Get("database_id").(string)
+	quotaID := strings.Split(d.Id(), "|")
+
+	req := &govultr.DatabaseQuotaUpdateReq{}
+	log.Printf("[INFO] Updating database quota (%s)", d.Id())
+
+	if d.HasChange("consumer_byte_rate") {
+		log.Print("[INFO] Updating `consumer_byte_rate`")
+		req.ConsumerByteRate = d.Get("consumer_byte_rate").(int)
+	}
+
+	if d.HasChange("producer_byte_rate") {
+		log.Print("[INFO] Updating `producer_byte_rate`")
+		req.ProducerByteRate = d.Get("producer_byte_rate").(int)
+	}
+
+	if d.HasChange("request_percentage") {
+		log.Print("[INFO] Updating `request_percentage`")
+		req.RequestPercentage = d.Get("request_percentage").(int)
+	}
+
+	if _, _, err := client.Database.UpdateQuota(ctx, databaseID, quotaID[0], quotaID[1], req); err != nil {
+		return diag.Errorf("error updating database quota %s : %s", d.Id(), err.Error())
+	}
+
+	return resourceVultrDatabaseQuotaRead(ctx, d, meta)
 }
 
 func resourceVultrDatabaseQuotaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/vultr/resource_vultr_database_quota.go
+++ b/vultr/resource_vultr_database_quota.go
@@ -37,17 +37,14 @@ func resourceVultrDatabaseQuota() *schema.Resource {
 			"consumer_byte_rate": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"producer_byte_rate": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"request_percentage": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"user": {
 				Type:     schema.TypeString,

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -60,6 +60,11 @@ The following attributes are exported:
 * `password` - The password for the managed database's primary admin user.
 * `access_key` - The private key to authenticate the default user (Kafka engine types only).
 * `access_cert` - The certificate to authenticate the default user (Kafka engine types only).
+* `enable_kafka_rest` - The configuration value for Kafka REST support (Kafka engine types only).
+* `kafka_rest_uri` - The URI to access the RESTful interface of your Kafka cluster if Kafka REST is enabled (Kafka engine types only).
+* `enable_schema_registry` - The configuration value for Schema Registry support (Kafka engine types only).
+* `schema_registry_uri` - The URI to access the Schema Registry service of your Kafka cluster if Schema Registry is enabled (Kafka engine types only).
+* `enable_kafka_connect` - The configuration value for Kafka Connect support (Kafka engine types only).
 * `maintenance_dow` - The preferred maintenance day of week for the managed database.
 * `maintenance_time` - The preferred maintenance time for the managed database.
 * `backup_hour` - The preferred hour of the day (UTC) for daily backups to take place (unavailable for Kafka engine types).

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -64,6 +64,9 @@ The following arguments are supported:
 * `mysql_require_primary_key` - (Optional) The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - (Optional) The configuration value for slow query logging on the managed database (MySQL engine types only).
 * `mysql_long_query_time` - (Optional) The configuration value for the long query time (in seconds) on the managed database (MySQL engine types only).
+* `enable_kafka_rest` - (Optional) The configuration value for Kafka REST support (Kafka engine types only).
+* `enable_schema_registry` - (Optional) The configuration value for Schema Registry support (Kafka engine types only).
+* `enable_kafka_connect` - (Optional) The configuration value for Kafka Connect support (Kafka engine types only).
 * `eviction_policy` - (Optional) The configuration value for the data eviction policy on the managed database (Valkey engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
 
 ## Attributes Reference
@@ -94,6 +97,11 @@ The following attributes are exported:
 * `password` - The password for the managed database's primary admin user.
 * `access_key` - The private key to authenticate the default user (Kafka engine types only).
 * `access_cert` - The certificate to authenticate the default user (Kafka engine types only).
+* `enable_kafka_rest` - The configuration value for Kafka REST support (Kafka engine types only).
+* `kafka_rest_uri` - The URI to access the RESTful interface of your Kafka cluster if Kafka REST is enabled (Kafka engine types only).
+* `enable_schema_registry` - The configuration value for Schema Registry support (Kafka engine types only).
+* `schema_registry_uri` - The URI to access the Schema Registry service of your Kafka cluster if Schema Registry is enabled (Kafka engine types only).
+* `enable_kafka_connect` - The configuration value for Kafka Connect support (Kafka engine types only).
 * `maintenance_dow` - The preferred maintenance day of week for the managed database.
 * `maintenance_time` - The preferred maintenance time for the managed database.
 * `backup_hour` - The preferred hour of the day (UTC) for daily backups to take place (unavailable for Kafka engine types).

--- a/website/docs/r/database_connector.html.markdown
+++ b/website/docs/r/database_connector.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "vultr"
+page_title: "Vultr: vultr_database_connector"
+sidebar_current: "docs-vultr-resource-database-connector"
+description: |-
+  Provides a Vultr database connector resource. This can be used to create, read, modify, and delete connectors for a managed database on your Vultr account.
+---
+
+# vultr_database_connector
+
+Provides a Vultr database connector resource. This can be used to create, read, modify, and delete connectors for a managed database on your Vultr account.
+
+## Example Usage
+
+Create a new database connector:
+
+```hcl
+resource "vultr_database_connector" "my_database_connector" {
+	database_id = vultr_database.my_database.id
+	name = "my_database_connector"
+	class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"
+	topics = "my_database_topic"
+	config = jsonencode({
+		couchbase.seed.nodes = 3
+		couchbase.username = "some_username"
+		couchbase.password = "some_password"
+	})
+}
+```
+
+## Argument Reference
+
+
+~> Updating the database ID, name, or class will cause a `force new`. This behavior is in place because a database connector cannot be moved from one managed database to another and connector names/classes cannot be updated.
+
+The following arguments are supported:
+
+* `database_id` - (Required) The managed database ID you want to attach this connector to.
+* `name` - (Required) The name for the new managed database connector.
+* `class` - (Required) The class for the new managed database connector.
+* `topics` - (Required) A comma-separated list of topics to use with the new managed database connector.
+* `config` - (Optional) A JSON string containing the configuration properties you wish to use with the new managed database connector.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `database_id` - The managed database ID.
+* `name` - The name of the managed database connector.
+* `class` - The class for the managed database connector.
+* `topics` - A comma-separated list of topics to use with the managed database connector.
+* `config` - A JSON string containing the configuration properties currently set for the managed database connector.

--- a/website/docs/r/database_connector.html.markdown
+++ b/website/docs/r/database_connector.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # vultr_database_connector
 
-Provides a Vultr database connector resource. This can be used to create, read, modify, and delete connectors for a managed database on your Vultr account.
+Provides a Vultr database connector resource. This can be used to create, read, modify, and delete connectors for a managed database on your Vultr account. Note: The managed database must be configured with `enable_kafka_connect = true`.
 
 ## Example Usage
 
@@ -21,9 +21,9 @@ resource "vultr_database_connector" "my_database_connector" {
 	class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"
 	topics = "my_database_topic"
 	config = jsonencode({
-		couchbase.seed.nodes = 3
-		couchbase.username = "some_username"
-		couchbase.password = "some_password"
+		"couchbase.seed.nodes" = "3"
+		"couchbase.username" = "some_username"
+		"couchbase.password" = "some_password"
 	})
 }
 ```

--- a/website/docs/r/database_quota.html.markdown
+++ b/website/docs/r/database_quota.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # vultr_database_quota
 
-Provides a Vultr database quota resource. This can be used to create, read, and delete quotas for a managed database on your Vultr account.
+Provides a Vultr database quota resource. This can be used to create, read, modify, and delete quotas for a managed database on your Vultr account.
 
 ## Example Usage
 
@@ -28,7 +28,7 @@ resource "vultr_database_quota" "my_database_quota" {
 ## Argument Reference
 
 
-~> Updating any field will cause a `force new`. This behavior is in place because quotas can only be replaced and not updated at this time, and they also cannot be moved from one managed database to another.
+~> Updating the database ID, client ID, or user will cause a `force new`. This behavior is in place because a database quota cannot be moved from one managed database to another and because quotas exist specifically for client ID/user pairs. 
 
 The following arguments are supported:
 


### PR DESCRIPTION
## Description
This PR includes feature updates for the Managed Kafka databases on Vultr. Particularly, new toggles for enabling Kafka REST, Schema Registry, and Kafka Connect are available along with URI fields for the former 2 features. Additionally, updates have been made to the database quotas resource to add support for the new update endpoint, with logic adjusted for the `ForceNew` behavior as well. Finally, a new resource for database connectors has been created for interacting with Kafka Connect, which includes relevant documentation and tests.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
