### PR TITLE
Add user_data field to kubernetes node pools

### DIFF
--- a/vultr/data_source_vultr_kubernetes.go
+++ b/vultr/data_source_vultr_kubernetes.go
@@ -238,6 +238,7 @@ func flattenNodePools(np []govultr.NodePool) []map[string]interface{} {
 			"nodes":         instances,
 			"labels":        n.Labels,
 			"taints":        taints,
+			"user_data":     n.UserData,
 		}
 
 		nodePools = append(nodePools, pool)

--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -291,8 +291,9 @@ func resourceVultrKubernetesUpdate(ctx context.Context, d *schema.ResourceData, 
 				MinNodes:     n["min_nodes"].(int),
 				MaxNodes:     n["max_nodes"].(int),
 				// Not updating tag for default node pool since it's needed to lookup in terraform
-				Labels: labels,
-				Taints: taints,
+				Labels:   labels,
+				Taints:   taints,
+				UserData: govultr.StringToStringPtr(n["user_data"].(string)),
 			}
 
 			if _, _, err := client.Kubernetes.UpdateNodePool(ctx, d.Id(), n["id"].(string), req); err != nil {
@@ -400,6 +401,7 @@ func generateNodePool(pools interface{}) []govultr.NodePoolReq {
 			MaxNodes:     r["max_nodes"].(int),
 			Labels:       labels,
 			Taints:       taints,
+			UserData:     r["user_data"].(string),
 		}
 
 		npr = append(npr, t)
@@ -488,6 +490,7 @@ func flattenNodePool(np *govultr.NodePool) []map[string]interface{} {
 		"max_nodes":     np.MaxNodes,
 		"labels":        labels,
 		"taints":        taints,
+		"user_data":     np.UserData,
 	}
 
 	nodePools = append(nodePools, pool)

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -52,6 +52,7 @@ func resourceVultrKubernetesNodePoolsCreate(ctx context.Context, d *schema.Resou
 		AutoScaler:   govultr.BoolToBoolPtr(d.Get("auto_scaler").(bool)),
 		MinNodes:     d.Get("min_nodes").(int),
 		MaxNodes:     d.Get("max_nodes").(int),
+		UserData:     d.Get("user_data").(string),
 	}
 
 	if labelsVal, labelsOK := d.GetOk("labels"); labelsOK {

--- a/vultr/vke.go
+++ b/vultr/vke.go
@@ -84,6 +84,10 @@ func nodePoolSchema(isNodePool bool) map[string]*schema.Schema {
 				},
 			},
 		},
+		"user_data": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		//computed fields
 		"id": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
- Add a `user_data` field to kubernetes node pools

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

### Testing
```hcl
resource "vultr_kubernetes" "vke" {
  region  = "yto"
  label   = "tf-user-data-test"
  version = "v1.33.0+3"

  node_pools {
    node_quantity = 3
    plan          = "vc2-4c-8gb"
    label         = "tf-user-data-np"
    user_data = "VGhpcyBpcyBhbHNvIHNvbWUgdGVzdCB1c2VyIGRhdGEK"
  }
} 

data "vultr_kubernetes" "vke-data" {
  filter {
    name = "label"
    values = [resource.vultr_kubernetes.vke.label]
  }
}

output "vke-labels-output" {
  value = data.vultr_kubernetes.vke-data.node_pools
}
```
