### PR TITLE
Add use_uefi field to snapshot from url resource

### DIFF
--- a/vultr/resource_vultr_snapshot_from_url.go
+++ b/vultr/resource_vultr_snapshot_from_url.go
@@ -29,6 +29,11 @@ func resourceVultrSnapshotFromURL() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"use_uefi": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"date_created": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -57,7 +62,8 @@ func resourceVultrSnapshotFromURLCreate(ctx context.Context, d *schema.ResourceD
 	client := meta.(*Client).govultrClient()
 
 	snapReq := &govultr.SnapshotURLReq{
-		URL: d.Get("url").(string),
+		URL:  d.Get("url").(string),
+		UEFI: govultr.BoolToBoolPtr(d.Get("use_uefi").(bool)),
 	}
 
 	snapshot, _, err := client.Snapshot.CreateFromURL(ctx, snapReq)


### PR DESCRIPTION
### **User description**
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Adds the `use_uefi` field to `snapshot_from_url`
### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?


___

### **PR Type**
Enhancement


___

### **Description**
- Add `use_uefi` optional boolean field

- Pass UEFI flag to Vultr API on create

- Mark field as ForceNew for replacement

- Update snapshot URL request struct


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Terraform resource vultr_snapshot_from_url"] -->|"new field"| B["use_uefi"]
  B -->|"mapped to"| C["govultr.SnapshotURLReq.UEFI"]
  C -->|"sent in"| D["CreateFromURL API call"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_vultr_snapshot_from_url.go</strong><dd><code>Add UEFI flag to snapshot-from-URL resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vultr/resource_vultr_snapshot_from_url.go

<ul><li>Introduce <code>use_uefi</code> optional boolean schema field<br> <li> Pass UEFI flag to govultr.SnapshotURLReq on create<br> <li> Set ForceNew=true to recreate resource on change</ul>


</details>


  </td>
  <td><a href="https://github.com/vultr/terraform-provider-vultr/pull/609/files#diff-55a41d4c92706e42e477eef216993da9f1f8cc452b8eef0b90076878a41a5d26">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

