### PR TITLE
Add node pool user data on two update scenarios

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -336,6 +336,7 @@ func resourceVultrKubernetesUpdate(ctx context.Context, d *schema.ResourceData, 
 				Label:        n["label"].(string),
 				Labels:       labels,
 				Taints:       taints,
+				UserData:     n["user_data"].(string),
 			}
 
 			if _, _, err := client.Kubernetes.CreateNodePool(ctx, d.Id(), req); err != nil {

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -220,6 +220,10 @@ func resourceVultrKubernetesNodePoolsUpdate(ctx context.Context, d *schema.Resou
 		req.Taints = taints
 	}
 
+	if d.HasChange("user_data") {
+		req.UserData = govultr.StringToStringPtr(d.Get("user_data").(string))
+	}
+
 	if _, _, err := client.Kubernetes.UpdateNodePool(ctx, clusterID, d.Id(), req); err != nil {
 		return diag.Errorf("error updating VKE node pool %v : %v", d.Id(), err)
 	}


### PR DESCRIPTION
### **User description**
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Add node pool user data on two update scenarios
- When updating a kubernetes_nodepool resource
- When updating the primary kubernetes resource node pool cause a new node pool to be created

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing user_data field on node pool creation

- Include user_data updates in node pool resource

- Fix user_data handling in primary cluster updates

- Ensure user_data persists across node pool operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kubernetes Resource Update"] --> B["Create Node Pool"]
  A --> C["Node Pool Resource Update"]
  B --> D["Include User Data"]
  C --> E["Update User Data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_vultr_kubernetes.go</strong><dd><code>Add user_data to node pool creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vultr/resource_vultr_kubernetes.go

<ul><li>Added UserData field to NodePoolReq when creating new node pool during <br>cluster update</ul>


</details>


  </td>
  <td><a href="https://github.com/vultr/terraform-provider-vultr/pull/613/files#diff-4af6273990358d6c00b83be9ed48a702c32b58c632d0e66a114a646c27caaf00">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resource_vultr_kubernetes_nodepools.go</strong><dd><code>Enable user_data updates in node pools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vultr/resource_vultr_kubernetes_nodepools.go

<ul><li>Added user_data field update handling in node pool update function<br> <li> Uses govultr.StringToStringPtr for proper string pointer conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/vultr/terraform-provider-vultr/pull/613/files#diff-f46dd19f8af0214887a44377acd1fb137c742d3323980e23b316c2b693508bc7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

