### PR TITLE
Add new API response fields for database, instance, and baremetal end…

### DIFF
--- a/vultr/data_source_vultr_bare_metal_server.go
+++ b/vultr/data_source_vultr_bare_metal_server.go
@@ -98,6 +98,10 @@ func dataSourceVultrBareMetalServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"features": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -214,6 +218,9 @@ func dataSourceVultrBareMetalServerRead(ctx context.Context, d *schema.ResourceD
 	}
 	if err := d.Set("image_id", serverList[0].ImageID); err != nil {
 		return diag.Errorf("unable to set bare_metal_server `image_id` read value: %v", err)
+	}
+	if err := d.Set("snapshot_id", serverList[0].SnapshotID); err != nil {
+		return diag.Errorf("unable to set bare_metal_server `snapshot_id` read value: %v", err)
 	}
 	if err := d.Set("v6_network", serverList[0].V6Network); err != nil {
 		return diag.Errorf("unable to set bare_metal_server `v6_network` read value: %v", err)

--- a/vultr/data_source_vultr_database.go
+++ b/vultr/data_source_vultr_database.go
@@ -156,6 +156,10 @@ func dataSourceVultrDatabase() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
+			"ca_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"mysql_sql_modes": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -386,6 +390,10 @@ func dataSourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("unable to set resource database `trusted_ips` read value: %v", err)
 	}
 
+	if err := d.Set("ca_certificate", databaseList[0].CACertificate); err != nil {
+		return diag.Errorf("unable to set resource database `ca_certificate` read value: %v", err)
+	}
+
 	if databaseList[0].DatabaseEngine == "mysql" {
 		if err := d.Set("mysql_sql_modes", databaseList[0].MySQLSQLModes); err != nil {
 			return diag.Errorf("unable to set resource database `mysql_sql_modes` read value: %v", err)
@@ -470,6 +478,7 @@ func flattenReplicas(db *govultr.Database) []map[string]interface{} {
 			"backup_minute":             *db.ReadReplicas[v].BackupMinute,
 			"latest_backup":             db.ReadReplicas[v].LatestBackup,
 			"trusted_ips":               db.ReadReplicas[v].TrustedIPs,
+			"ca_certificate":            db.ReadReplicas[v].CACertificate,
 			"mysql_sql_modes":           db.ReadReplicas[v].MySQLSQLModes,
 			"mysql_require_primary_key": db.ReadReplicas[v].MySQLRequirePrimaryKey,
 			"mysql_slow_query_log":      db.ReadReplicas[v].MySQLSlowQueryLog,

--- a/vultr/data_source_vultr_instance.go
+++ b/vultr/data_source_vultr_instance.go
@@ -123,6 +123,10 @@ func dataSourceVultrInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"firewall_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -264,6 +268,9 @@ func dataSourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	if err := d.Set("image_id", serverList[0].ImageID); err != nil {
 		return diag.Errorf("unable to set instance `image_id` read value: %v", err)
+	}
+	if err := d.Set("snapshot_id", serverList[0].SnapshotID); err != nil {
+		return diag.Errorf("unable to set instance `snapshot_id` read value: %v", err)
 	}
 	if err := d.Set("firewall_group_id", serverList[0].FirewallGroupID); err != nil {
 		return diag.Errorf("unable to set instance `firewall_group_id` read value: %v", err)

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -132,6 +132,10 @@ func dataSourceVultrInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"snapshot_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"firewall_group_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -233,6 +237,7 @@ func dataSourceVultrInstancesRead(ctx context.Context, d *schema.ResourceData, m
 					"os_id":               server.OsID,
 					"app_id":              server.AppID,
 					"image_id":            server.ImageID,
+					"snapshot_id":         server.SnapshotID,
 					"firewall_group_id":   server.FirewallGroupID,
 					"v6_network":          server.V6Network,
 					"v6_main_ip":          server.V6MainIP,

--- a/vultr/resource_vultr_bare_metal_server.go
+++ b/vultr/resource_vultr_bare_metal_server.go
@@ -61,11 +61,6 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"snapshot_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			"enable_ipv6": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -115,6 +110,12 @@ func resourceVultrBareMetalServer() *schema.Resource {
 				Optional: true,
 			},
 			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+				Optional: true,
+			},
+			"snapshot_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 				ForceNew: true,
@@ -389,6 +390,9 @@ func resourceVultrBareMetalServerRead(ctx context.Context, d *schema.ResourceDat
 	}
 	if err := d.Set("image_id", bms.ImageID); err != nil {
 		return diag.Errorf("unable to set resource bare_metal_server `image_id` read value: %v", err)
+	}
+	if err := d.Set("snapshot_id", bms.SnapshotID); err != nil {
+		return diag.Errorf("unable to set resource bare_metal_server `snapshot_id` read value: %v", err)
 	}
 	if err := d.Set("v6_network", bms.V6Network); err != nil {
 		return diag.Errorf("unable to set resource bare_metal_server `v6_network` read value: %v", err)

--- a/vultr/resource_vultr_database.go
+++ b/vultr/resource_vultr_database.go
@@ -217,6 +217,10 @@ func resourceVultrDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ca_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"read_replicas": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -510,6 +514,10 @@ func resourceVultrDatabaseRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if err := d.Set("trusted_ips", database.TrustedIPs); err != nil {
 		return diag.Errorf("unable to set resource database `trusted_ips` read value: %v", err)
+	}
+
+	if err := d.Set("ca_certificate", database.CACertificate); err != nil {
+		return diag.Errorf("unable to set resource database `ca_certificate` read value: %v", err)
 	}
 
 	if database.DatabaseEngine == "mysql" {

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -522,6 +522,12 @@ func resourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	if err := d.Set("app_id", instance.AppID); err != nil {
 		return diag.Errorf("unable to set resource instance `app_id` read value: %v", err)
 	}
+	if err := d.Set("image_id", instance.ImageID); err != nil {
+		return diag.Errorf("unable to set resource instance `image_id` read value: %v", err)
+	}
+	if err := d.Set("snapshot_id", instance.SnapshotID); err != nil {
+		return diag.Errorf("unable to set resource instance `snapshot_id` read value: %v", err)
+	}
 	if err := d.Set("features", instance.Features); err != nil {
 		return diag.Errorf("unable to set resource instance `features` read value: %v", err)
 	}

--- a/website/docs/d/bare_metal_server.html.markdown
+++ b/website/docs/d/bare_metal_server.html.markdown
@@ -59,5 +59,6 @@ The following attributes are exported:
 * `os_id` - The server's operating system ID.
 * `app_id` - The server's application ID.
 * `image_id` - The Marketplace ID for this application.
+* `snapshot_id` - The ID of the Vultr snapshot that the server was restored from.
 * `vpc_id` - The ID of the VPC which is attached to the bare metal server.
 * `vpc2_ids` - (Deprecated) A list of VPC 2.0 IDs attached to the server.

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -71,6 +71,7 @@ The following attributes are exported:
 * `backup_minute` - The preferred minute of the backup hour for daily backups to take place (unavailable for Kafka engine types).
 * `latest_backup` - The date of the latest backup available on the managed database.
 * `trusted_ips` - A list of allowed IP addresses for the managed database.
+* `ca_certificate` - The CA certificate for Managed Databases on this account.
 * `mysql_sql_modes` - A list of SQL modes currently configured for the managed database (MySQL engine types only).
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database (MySQL engine types only).

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -64,6 +64,7 @@ The following attributes are exported:
 * `os_id` - The server's operating system ID.
 * `app_id` - The server's application ID.
 * `image_id` - The Marketplace ID for this application.
+* `snapshot_id` - The ID of the Vultr snapshot that the server was restored from.
 * `firewall_group_id` - The ID of the firewall group applied to this server.
 * `features` - Array of which features are enabled.
 * `backups_schedule` - The current configuration for backups 

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -70,6 +70,7 @@ The following attributes are exported:
   * `os_id` - The server's operating system ID.
   * `app_id` - The server's application ID.
   * `image_id` - The Marketplace ID for this application.
+  * `snapshot_id` - The ID of the Vultr snapshot that the server was restored from.
   * `firewall_group_id` - The ID of the firewall group applied to this server.
   * `features` - Array of which features are enabled.
   * `backups_schedule` - The current configuration for backups 

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -108,6 +108,7 @@ The following attributes are exported:
 * `backup_minute` - The preferred minute of the backup hour for daily backups to take place (unavailable for Kafka engine types).
 * `latest_backup` - The date of the latest backup available on the managed database.
 * `trusted_ips` - A list of allowed IP addresses for the managed database.
+* `ca_certificate` - The CA certificate for Managed Databases on this account.
 * `mysql_sql_modes` - A list of SQL modes currently configured for the managed database (MySQL engine types only).
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database (MySQL engine types only).

--- a/website/docs/r/database_replica.html.markdown
+++ b/website/docs/r/database_replica.html.markdown
@@ -66,6 +66,7 @@ The following attributes are exported:
 * `backup_minute` - The preferred minute of the backup hour for daily backups to take place (unavailable for Kafka engine types).
 * `latest_backup` - The date of the latest backup available on the managed database read replica.
 * `trusted_ips` - A list of allowed IP addresses for the managed database read replica.
+* `ca_certificate` - The CA certificate for Managed Databases on this account.
 * `mysql_sql_modes` - A list of SQL modes currently configured for the managed database read replica (MySQL engine types only).
 * `mysql_require_primary_key` - The configuration value for whether primary keys are required on the managed database read replica (MySQL engine types only).
 * `mysql_slow_query_log` - The configuration value for slow query logging on the managed database read replica (MySQL engine types only).


### PR DESCRIPTION
## Description
This PR adds some new API fields for a few different resources:

- `databases` - added `ca_certificate` field
- `instances` - added `snapshot_id` field
- `bare-metals` - added `snapshot_id` field

Also added a missing `image_id` field from the instance read response, which is consistently part of the API response and already in the relevant data source.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
