### PR TITLE
fix: add missing label attribute read in vultr_instance

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -534,6 +534,9 @@ func resourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	if err := d.Set("hostname", instance.Hostname); err != nil {
 		return diag.Errorf("unable to set resource instance `hostname` read value: %v", err)
 	}
+	if err := d.Set("label", instance.Label); err != nil {
+		return diag.Errorf("unable to set resource instance `label` read value: %v", err)
+	}
 	if err := d.Set("user_scheme", instance.UserScheme); err != nil {
 		return diag.Errorf("unable to set resource instance `user_scheme` read value: %v", err)
 	}


### PR DESCRIPTION
Description
Add missing label attribute read in resourceVultrInstanceRead. Currently, the label field is not synced from the API during refresh/import operations, preventing Terraform from detecting drift when the label is changed outside of Terraform.

Related Issues
Fixes label drift detection for vultr_instance resource.

Checklist:
[x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
[x] Have you linted your code locally prior to submission?
[x] Have you successfully ran tests with your changes locally?