### PR TITLE
Avoid empty PATCH on block storage update

### DIFF
--- a/vultr/resource_vultr_block_storage.go
+++ b/vultr/resource_vultr_block_storage.go
@@ -183,17 +183,19 @@ func resourceVultrBlockStorageRead(ctx context.Context, d *schema.ResourceData, 
 func resourceVultrBlockStorageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Client).govultrClient()
 
-	blockReq := &govultr.BlockStorageUpdate{}
-	if d.HasChange("label") {
-		blockReq.Label = d.Get("label").(string)
-	}
+	if d.HasChange("label") || d.HasChange("size_gb") {
+		blockReq := &govultr.BlockStorageUpdate{}
+		if d.HasChange("label") {
+			blockReq.Label = d.Get("label").(string)
+		}
 
-	if d.HasChange("size_gb") {
-		blockReq.SizeGB = d.Get("size_gb").(int)
-	}
+		if d.HasChange("size_gb") {
+			blockReq.SizeGB = d.Get("size_gb").(int)
+		}
 
-	if err := client.BlockStorage.Update(ctx, d.Id(), blockReq); err != nil {
-		return diag.Errorf("error updating block storage: %v", err)
+		if err := client.BlockStorage.Update(ctx, d.Id(), blockReq); err != nil {
+			return diag.Errorf("error updating block storage: %v", err)
+		}
 	}
 
 	if d.HasChange("attached_to_instance") {

--- a/vultr/resource_vultr_block_storage.go
+++ b/vultr/resource_vultr_block_storage.go
@@ -193,7 +193,7 @@ func resourceVultrBlockStorageUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err := client.BlockStorage.Update(ctx, d.Id(), blockReq); err != nil {
-		return diag.Errorf("error getting block storage: %v", err)
+		return diag.Errorf("error updating block storage: %v", err)
 	}
 
 	if d.HasChange("attached_to_instance") {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The API has changed and now returns `"Nothing to change","status":400` when a PATCH with an empty body is sent.  This makes the provider check that the two block storage fields are actually being changed before sending the PATCH.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Resolves #660 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
