### PR TITLE
Mark instance KVM URLs as sensitive

### DIFF
--- a/vultr/data_source_vultr_instance.go
+++ b/vultr/data_source_vultr_instance.go
@@ -95,8 +95,9 @@ func dataSourceVultrInstance() *schema.Resource {
 				Computed: true,
 			},
 			"kvm": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"backups": {
 				Type:     schema.TypeString,

--- a/vultr/data_source_vultr_instances.go
+++ b/vultr/data_source_vultr_instances.go
@@ -104,8 +104,9 @@ func dataSourceVultrInstances() *schema.Resource {
 							Computed: true,
 						},
 						"kvm": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"backups": {
 							Type:     schema.TypeString,

--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -281,8 +281,9 @@ hostname on UI or API issues a reinstall of the OS.`,
 				Computed: true,
 			},
 			"kvm": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"features": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
## Description
Marks the instance kvm URL as sensitive so tokenized noVNC links (which contain auth tokens) aren’t shown in plan output. Applies to the instance resource and both instance data sources.

## Related Issues
N/A

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?

