### PR TITLE
ignore node count when autoscaler is enabled

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -337,8 +337,12 @@ func resourceVultrKubernetesUpdate(ctx context.Context, d *schema.ResourceData, 
 		oldNodePoolData := oldNodePool.(map[string]interface{})
 		newNodePoolData := newNodePool.(map[string]interface{})
 
-		req := &govultr.NodePoolReqUpdate{
-			NodeQuantity: newNodePoolData["node_quantity"].(int),
+		req := &govultr.NodePoolReqUpdate{}
+
+		// Only send node_quantity when auto_scaler is disabled
+		// When auto_scaler is enabled, the cluster autoscaler manages node count
+		if !newNodePoolData["auto_scaler"].(bool) {
+			req.NodeQuantity = newNodePoolData["node_quantity"].(int)
 		}
 
 		if newNodePoolData["auto_scaler"] != oldNodePoolData["auto_scaler"] {

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -305,8 +305,13 @@ func resourceVultrKubernetesNodePoolsUpdate(ctx context.Context, d *schema.Resou
 	clusterID := d.Get("cluster_id").(string)
 
 	req := &govultr.NodePoolReqUpdate{
-		NodeQuantity: d.Get("node_quantity").(int),
-		Tag:          govultr.StringToStringPtr(d.Get("tag").(string)),
+		Tag: govultr.StringToStringPtr(d.Get("tag").(string)),
+	}
+
+	// Only send node_quantity when auto_scaler is disabled
+	// When auto_scaler is enabled, the cluster autoscaler manages node count
+	if !d.Get("auto_scaler").(bool) {
+		req.NodeQuantity = d.Get("node_quantity").(int)
 	}
 
 	if d.HasChange("auto_scaler") {

--- a/vultr/vke.go
+++ b/vultr/vke.go
@@ -236,6 +236,13 @@ func resourceVultrKubernetesNodePoolsV0(isNodePool bool) *schema.Resource {
 				Type:         schema.TypeInt,
 				ValidateFunc: validation.IntAtLeast(1),
 				Required:     true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// When auto_scaler is enabled, node count is managed by cluster autoscaler
+					if autoScaler, ok := d.GetOk("auto_scaler"); ok && autoScaler.(bool) {
+						return true
+					}
+					return false
+				},
 			},
 			"auto_scaler": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
## Description
When you have autoscaler enabled, you would normally just set `ignore_changes` on node count. This just makes it so you don't have to do that when you have autoscaler enabled

