### PR TITLE
change attached instances from list to set

### DIFF
--- a/vultr/data_source_vultr_load_balancer.go
+++ b/vultr/data_source_vultr_load_balancer.go
@@ -60,7 +60,7 @@ func dataSourceVultrLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 			"attached_instances": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
## Description

The ordering from the API response of attached instances was causing false diffs