### PR TITLE
resource/vultr_firewall_group: remove count fields from schema

### DIFF
--- a/vultr/resource_vultr_firewall_group.go
+++ b/vultr/resource_vultr_firewall_group.go
@@ -33,18 +33,6 @@ func resourceVultrFirewallGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"instance_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"rule_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"max_rule_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -86,15 +74,6 @@ func resourceVultrFirewallGroupRead(ctx context.Context, d *schema.ResourceData,
 	}
 	if err := d.Set("date_modified", group.DateModified); err != nil {
 		return diag.Errorf("unable to set resource firewall_group `date_modified` read value: %v", err)
-	}
-	if err := d.Set("instance_count", group.InstanceCount); err != nil {
-		return diag.Errorf("unable to set resource firewall_group `instance_count` read value: %v", err)
-	}
-	if err := d.Set("rule_count", group.RuleCount); err != nil {
-		return diag.Errorf("unable to set resource firewall_group `rule_count` read value: %v", err)
-	}
-	if err := d.Set("max_rule_count", group.MaxRuleCount); err != nil {
-		return diag.Errorf("unable to set resource firewall_group `max_rule_count` read value: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
The fields instance_count, rule_count, and max_rule_count in the firewall group API are causing timeout issues on larger accounts because the way those tables work. I am removing them from the API by default, unless you pass `?show_counts=true`. 

So this MR just removes them from TF to prevent a diff from happening since they're computed

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
