### PR TITLE
Fix panic in kubernetes state upgraders on nil/empty fields (#709)

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -41,7 +41,18 @@ func resourceVultrKubernetesStateUpgradeV0ToV1(ctx context.Context, rawState map
 		return rawState, nil
 	}
 
-	migrateState := rawState["node_pools"].([]interface{})[0].(map[string]interface{})
+	nodePools, ok := rawState["node_pools"].([]interface{})
+	if !ok || len(nodePools) == 0 {
+		log.Println("[INFO] skipping kubernetes state migration: node_pools is nil or empty")
+		return rawState, nil
+	}
+
+	migrateState, ok := nodePools[0].(map[string]interface{})
+	if !ok {
+		log.Println("[INFO] skipping kubernetes state migration: node_pools[0] is not a map")
+		return rawState, nil
+	}
+
 	migrateState["cluster_id"] = rawState["id"]
 
 	nps, err := resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -60,6 +60,8 @@ func resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(ctx context.Context, raw
 		log.Println("[INFO] skipping kubernetes node pool state migration: labels and taints are nil or empty")
 		delete(rawState, "labels")
 		rawState["labels"] = []map[string]interface{}{}
+		delete(rawState, "taints")
+		rawState["taints"] = []interface{}{}
 		return rawState, nil
 	}
 
@@ -122,6 +124,8 @@ func resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(ctx context.Context, raw
 		}
 	} else {
 		log.Println("[INFO] skipping kubernetes node pool taints migration: taints is nil or empty")
+		delete(rawState, "taints")
+		rawState["taints"] = []interface{}{}
 	}
 
 	return rawState, nil

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -52,58 +52,76 @@ func resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(ctx context.Context, raw
 		return rawState, nil
 	}
 
+	stateLabels, labelsOk := rawState["labels"].(map[string]interface{})
+	stateTaints, taintsOk := rawState["taints"].([]interface{})
+
+	// Only get the client if we have labels or taints to migrate
+	if (!labelsOk || len(stateLabels) == 0) && (!taintsOk || len(stateTaints) == 0) {
+		log.Println("[INFO] skipping kubernetes node pool state migration: labels and taints are nil or empty")
+		delete(rawState, "labels")
+		rawState["labels"] = []map[string]interface{}{}
+		return rawState, nil
+	}
+
 	client := meta.(*Client).govultrClient()
 
-	stateLabels := rawState["labels"].(map[string]interface{})
-	stateTaints := rawState["taints"].([]interface{})
+	if labelsOk && len(stateLabels) > 0 {
+		log.Println("[INFO] migrating kubernetes node pool labels from v0 to v1")
+		refLabels, _, err := client.Kubernetes.ListNodePoolLabels(
+			ctx,
+			rawState["cluster_id"].(string),
+			rawState["id"].(string),
+		)
+		if err != nil {
+			log.Println("[ERROR] unable to retrieve updated kubernetes node pool labels from client")
+			return rawState, err
+		}
 
-	log.Println("[INFO] migrating kubernetes node pool labels from v0 to v1")
-	refLabels, _, err := client.Kubernetes.ListNodePoolLabels(
-		ctx,
-		rawState["cluster_id"].(string),
-		rawState["id"].(string),
-	)
-	if err != nil {
-		log.Println("[ERROR] unable to retrieve updated kubernetes node pool labels from client")
-		return rawState, err
-	}
+		newStateLabels := []map[string]interface{}{}
+		for j := range refLabels {
+			for key, val := range stateLabels {
+				newStateLabel := map[string]interface{}{}
+				if key == refLabels[j].Key {
+					newStateLabel["key"] = key
+					newStateLabel["value"] = val.(string)
+					newStateLabel["id"] = refLabels[j].ID
 
-	newStateLabels := []map[string]interface{}{}
-	for j := range refLabels {
-		for key, val := range stateLabels {
-			newStateLabel := map[string]interface{}{}
-			if key == refLabels[j].Key {
-				newStateLabel["key"] = key
-				newStateLabel["value"] = val.(string)
-				newStateLabel["id"] = refLabels[j].ID
-
-				newStateLabels = append(newStateLabels, newStateLabel)
+					newStateLabels = append(newStateLabels, newStateLabel)
+				}
 			}
 		}
+
+		// replace the labels state
+		delete(rawState, "labels")
+		rawState["labels"] = newStateLabels
+	} else {
+		log.Println("[INFO] skipping kubernetes node pool labels migration: labels is nil or empty")
+		delete(rawState, "labels")
+		rawState["labels"] = []map[string]interface{}{}
 	}
 
-	// replace the labels state
-	delete(rawState, "labels")
-	rawState["labels"] = newStateLabels
+	if taintsOk && len(stateTaints) > 0 {
+		log.Println("[INFO] migrating kubernetes node pool taints from v0 to v1")
+		refTaints, _, err := client.Kubernetes.ListNodePoolTaints(
+			ctx,
+			rawState["cluster_id"].(string),
+			rawState["id"].(string),
+		)
+		if err != nil {
+			log.Println("[ERROR] unable to retrieve updated kubernetes node pool taints from client")
+			return rawState, err
+		}
 
-	log.Println("[INFO] migrating kubernetes node pool taints from v0 to v1")
-	refTaints, _, err := client.Kubernetes.ListNodePoolTaints(
-		ctx,
-		rawState["cluster_id"].(string),
-		rawState["id"].(string),
-	)
-	if err != nil {
-		log.Println("[ERROR] unable to retrieve updated kubernetes node pool taints from client")
-		return rawState, err
-	}
-
-	for j := range refTaints {
-		for k := range stateTaints {
-			stateTaintData := stateTaints[k].(map[string]interface{})
-			if stateTaintData["key"] == refTaints[j].Key {
-				stateTaintData["id"] = refTaints[j].ID
+		for j := range refTaints {
+			for k := range stateTaints {
+				stateTaintData := stateTaints[k].(map[string]interface{})
+				if stateTaintData["key"] == refTaints[j].Key {
+					stateTaintData["id"] = refTaints[j].ID
+				}
 			}
 		}
+	} else {
+		log.Println("[INFO] skipping kubernetes node pool taints migration: taints is nil or empty")
 	}
 
 	return rawState, nil

--- a/vultr/resource_vultr_kubernetes_state_upgrade_test.go
+++ b/vultr/resource_vultr_kubernetes_state_upgrade_test.go
@@ -1,0 +1,117 @@
+package vultr
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResourceVultrKubernetesStateUpgradeV0ToV1_NodePoolsNil(t *testing.T) {
+	rawState := map[string]interface{}{
+		"id":     "test-cluster-id",
+		"label":  "test-cluster",
+		"region": "ewr",
+	}
+
+	upgraded, err := resourceVultrKubernetesStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if upgraded["id"] != "test-cluster-id" {
+		t.Errorf("expected id to be preserved, got: %v", upgraded["id"])
+	}
+}
+
+func TestResourceVultrKubernetesStateUpgradeV0ToV1_NodePoolsEmpty(t *testing.T) {
+	rawState := map[string]interface{}{
+		"id":         "test-cluster-id",
+		"label":      "test-cluster",
+		"node_pools": []interface{}{},
+	}
+
+	upgraded, err := resourceVultrKubernetesStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if upgraded["id"] != "test-cluster-id" {
+		t.Errorf("expected id to be preserved, got: %v", upgraded["id"])
+	}
+}
+
+func TestResourceVultrKubernetesStateUpgradeV0ToV1_EmptyRawState(t *testing.T) {
+	rawState := map[string]interface{}{}
+
+	upgraded, err := resourceVultrKubernetesStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(upgraded) != 0 {
+		t.Errorf("expected empty map, got: %v", upgraded)
+	}
+}
+
+func TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_LabelsNil(t *testing.T) {
+	rawState := map[string]interface{}{
+		"id":         "test-np-id",
+		"cluster_id": "test-cluster-id",
+		"labels":     nil,
+		"taints":     nil,
+	}
+
+	upgraded, err := resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if upgraded["id"] != "test-np-id" {
+		t.Errorf("expected id to be preserved, got: %v", upgraded["id"])
+	}
+}
+
+func TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_LabelsEmpty(t *testing.T) {
+	rawState := map[string]interface{}{
+		"id":         "test-np-id",
+		"cluster_id": "test-cluster-id",
+		"labels":     map[string]interface{}{},
+		"taints":     []interface{}{},
+	}
+
+	upgraded, err := resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if upgraded["id"] != "test-np-id" {
+		t.Errorf("expected id to be preserved, got: %v", upgraded["id"])
+	}
+}
+
+func TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_EmptyRawState(t *testing.T) {
+	rawState := map[string]interface{}{}
+
+	upgraded, err := resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(upgraded) != 0 {
+		t.Errorf("expected empty map, got: %v", upgraded)
+	}
+}
+
+func TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_TaintsNil(t *testing.T) {
+	rawState := map[string]interface{}{
+		"id":         "test-np-id",
+		"cluster_id": "test-cluster-id",
+		"labels":     nil,
+		"taints":     nil,
+	}
+
+	upgraded, err := resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if upgraded["id"] != "test-np-id" {
+		t.Errorf("expected id to be preserved, got: %v", upgraded["id"])
+	}
+	// labels should be set to empty slice when nil
+	if upgraded["labels"] == nil {
+		t.Error("expected labels to be set to empty slice, got nil")
+	}
+}


### PR DESCRIPTION
# Edit:
I thought the crash was because it was pulling from the API. This was wrong. Closing since wrong solutions 

## Description
Because we changed the taints and labels APIs, the V0 to V1 state upgraders for vultr_kubernetes and vultr_kubernetes_node_pools contained nil-unsafe type assertions that caused panics when node_pools, labels, or taints were nil or empty in existing state. A panic in UpgradeResourceState kills the entire gRPC plugin process, causing all subsequent resource calls to fail with 'Plugin did not respond'. Would even happen for unrelated resources.

Fixes:
- Guard rawState["node_pools"] with safe type assertion + length check before indexing in resourceVultrKubernetesStateUpgradeV0ToV1
- Guard rawState["labels"] and rawState["taints"] with comma-ok type assertions in resourceVultrKubernetesNodePoolsStateUpgradeV0ToV1
- Defer client initialization until after nil/empty checks so we don't need the API client when there's nothing to migrate
- Add unit tests for all nil/empty crash scenarios

## Related Issues
Closes #709


### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?


### Test results:
```
PASS: TestProvider
PASS: TestResourceVultrKubernetesStateUpgradeV0ToV1_NodePoolsNil
PASS: TestResourceVultrKubernetesStateUpgradeV0ToV1_NodePoolsEmpty
PASS: TestResourceVultrKubernetesStateUpgradeV0ToV1_EmptyRawState
PASS: TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_LabelsNil
PASS: TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_LabelsEmpty
PASS: TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_EmptyRawState
PASS: TestResourceVultrKubernetesNodePoolsStateUpgradeV0ToV1_TaintsNil

ok  github.com/vultr/terraform-provider-vultr/vultr  7.079s
```
