### PR TITLE
Add ca_certificate to database replica resource

### DIFF
--- a/vultr/database.go
+++ b/vultr/database.go
@@ -139,6 +139,10 @@ func readReplicaSchema(isReadReplica bool) map[string]*schema.Schema {
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
+		"ca_certificate": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"mysql_sql_modes": {
 			Type:     schema.TypeSet,
 			Computed: true,

--- a/vultr/resource_vultr_database_replica.go
+++ b/vultr/resource_vultr_database_replica.go
@@ -212,6 +212,10 @@ func resourceVultrDatabaseReplicaRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("unable to set resource database read replica `trusted_ips` read value: %v", err)
 	}
 
+	if err := d.Set("ca_certificate", database.CACertificate); err != nil {
+		return diag.Errorf("unable to set resource database read replica `ca_certificate` read value: %v", err)
+	}
+
 	if database.DatabaseEngine == "mysql" {
 		if err := d.Set("mysql_sql_modes", database.MySQLSQLModes); err != nil {
 			return diag.Errorf("unable to set resource database read replica `mysql_sql_modes` read value: %v", err)


### PR DESCRIPTION
## Description
This PR adds the missing `ca_certificate` field to the database read replica resource. The flatten function was looking for it, but it wasn't defined in the schema.

## Related Issues
Fixes #662 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
