### PR TITLE
Add tier_id to object storage state import

### DIFF
--- a/vultr/resource_vultr_object_storage.go
+++ b/vultr/resource_vultr_object_storage.go
@@ -35,7 +35,9 @@ func resourceVultrObjectStorage() *schema.Resource {
 
 					for i := range obs {
 						if obs[i].ID == d.Id() {
-							d.Set("tier_id", obs[i].Tier.ID)
+							if err := d.Set("tier_id", obs[i].Tier.ID); err != nil {
+								return nil, fmt.Errorf("unable to set tier_id during import of object storage: %v", err)
+							}
 						}
 					}
 

--- a/vultr/resource_vultr_object_storage.go
+++ b/vultr/resource_vultr_object_storage.go
@@ -22,6 +22,8 @@ func resourceVultrObjectStorage() *schema.Resource {
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				client := meta.(*Client).govultrClient()
 
+				d.SetId(d.Id())
+
 				// tier_id will cause replacement if not set on import. The
 				// tier_id only returns on the list call so we have to list all
 				// object storages, check for matching ID and take the tier ID
@@ -38,6 +40,8 @@ func resourceVultrObjectStorage() *schema.Resource {
 							if err := d.Set("tier_id", obs[i].Tier.ID); err != nil {
 								return nil, fmt.Errorf("unable to set tier_id during import of object storage: %v", err)
 							}
+
+							return []*schema.ResourceData{d}, nil
 						}
 					}
 
@@ -49,9 +53,7 @@ func resourceVultrObjectStorage() *schema.Resource {
 					}
 				}
 
-				d.SetId(d.Id())
-
-				return []*schema.ResourceData{d}, nil
+				return nil, fmt.Errorf("unable to import object storage")
 			},
 		},
 		Schema: map[string]*schema.Schema{

--- a/vultr/resource_vultr_object_storage.go
+++ b/vultr/resource_vultr_object_storage.go
@@ -19,7 +19,38 @@ func resourceVultrObjectStorage() *schema.Resource {
 		UpdateContext: resourceVultrObjectStorageUpdate,
 		DeleteContext: resourceVultrObjectStorageDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				client := meta.(*Client).govultrClient()
+
+				// tier_id will cause replacement if not set on import. The
+				// tier_id only returns on the list call so we have to list all
+				// object storages, check for matching ID and take the tier ID
+				// from that response
+				listOpts := govultr.ListOptions{}
+				for {
+					obs, meta, _, err := client.ObjectStorage.List(ctx, &listOpts)
+					if err != nil {
+						return nil, fmt.Errorf("error during import of object storage: %v", err)
+					}
+
+					for i := range obs {
+						if obs[i].ID == d.Id() {
+							d.Set("tier_id", obs[i].Tier.ID)
+						}
+					}
+
+					if meta.Links.Next == "" {
+						break
+					} else {
+						listOpts.Cursor = meta.Links.Next
+						continue
+					}
+				}
+
+				d.SetId(d.Id())
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
If the tier_id isn't imported into state, it will forever cause terraform to try to replace the resource.  Since that field is not present in the API response for the state refresh, it must be retrieved from the object storage list endpoint instead.  This PR adds a state context function to loop through the list response and retrieve the `tier_id` and save it to state.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
