### PR TITLE
Add composite key import for VPC NAT gateway

### DIFF
--- a/vultr/resource_vultr_nat_gateway.go
+++ b/vultr/resource_vultr_nat_gateway.go
@@ -27,7 +27,7 @@ func resourceVultrNATGateway() *schema.Resource {
 				strngs := strings.SplitN(d.Id(), "_", 2)
 				if len(strngs) != 2 {
 					return nil, fmt.Errorf(`unable to import vpc nat gateway: 
-the composite import id must be formatted as <VPC UUID>_<NAT UUID>, recieved %q`, d.Id())
+the composite import id must be formatted as <VPC UUID>_<NAT UUID>, received %q`, d.Id())
 				}
 
 				d.SetId(strngs[1])

--- a/vultr/resource_vultr_nat_gateway.go
+++ b/vultr/resource_vultr_nat_gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -20,7 +21,27 @@ func resourceVultrNATGateway() *schema.Resource {
 		UpdateContext: resourceVultrNATGatewayUpdate,
 		DeleteContext: resourceVultrNATGatewayDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				client := meta.(*Client).govultrClient()
+
+				strngs := strings.SplitN(d.Id(), "_", 2)
+				if len(strngs) != 2 {
+					return nil, fmt.Errorf(`unable to import vpc nat gateway: 
+the composite import id must be formatted as <VPC UUID>_<NAT UUID>, recieved %q`, d.Id())
+				}
+
+				d.SetId(strngs[1])
+
+				if _, _, err := client.VPC.GetNATGateway(ctx, strngs[0], strngs[1]); err != nil {
+					return nil, fmt.Errorf("unable to import vpc nat gateway: %v", err)
+				}
+
+				if err := d.Set("vpc_id", strngs[0]); err != nil {
+					return nil, fmt.Errorf("unable to set vpc_id on vpc nat gateway: %v", err)
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 		Schema: map[string]*schema.Schema{
 			// Required

--- a/website/docs/r/nat_gateway.markdown
+++ b/website/docs/r/nat_gateway.markdown
@@ -46,3 +46,12 @@ The following attributes are exported:
 * `private_ips` - The private IP addresses of the NAT Gateway.
 * `billing_charges` - The current charges for the NAT Gateway.
 * `billing_monthly` - The total monthly charges for the NAT Gateway.
+
+## Import
+NAT gateways rely on a VPC ID as well as their own ID. To import we look up the
+NAT gateway via a composite key formatted like `<VPC UUID>_<NAT UUID>` (the two
+UUIDs serparated by an underscore). The import will look like:
+
+```
+terraform import vultr_nat_gateway.my_ngw 7ceab21c-e35b-4efb-9e96-6026ff5de5aa_f5dc2455-b748-4a8c-a8ac-5eef9c2ebfb7
+```

--- a/website/docs/r/nat_gateway.markdown
+++ b/website/docs/r/nat_gateway.markdown
@@ -50,7 +50,7 @@ The following attributes are exported:
 ## Import
 NAT gateways rely on a VPC ID as well as their own ID. To import we look up the
 NAT gateway via a composite key formatted like `<VPC UUID>_<NAT UUID>` (the two
-UUIDs serparated by an underscore). The import will look like:
+UUIDs separated by an underscore). The import will look like:
 
 ```
 terraform import vultr_nat_gateway.my_ngw 7ceab21c-e35b-4efb-9e96-6026ff5de5aa_f5dc2455-b748-4a8c-a8ac-5eef9c2ebfb7


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Adds composite key import for NAT gateways since they are children of VPCs and must reference the parent UUID. 

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #689

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
