### PR TITLE
Update govultr from v3.30.0 to v3.31.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ main.tf
 .idea
 terraform-provider-vultr
 terraform-provider-vultr.exe
+vendor

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
-	github.com/vultr/govultr/v3 v3.30.0
+	github.com/vultr/govultr/v3 v3.31.1
 	golang.org/x/oauth2 v0.36.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vultr/govultr/v3 v3.30.0 h1:kTeDJ+5or6g4CQJmD6Kmz4R63B18poNZ8RP87r9LZdg=
-github.com/vultr/govultr/v3 v3.30.0/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
+github.com/vultr/govultr/v3 v3.31.1 h1:AoJRZ0WDS1J1otp2wk3OD4aYh4EQxFU+kvyOPdCe4+Y=
+github.com/vultr/govultr/v3 v3.31.1/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vultr/data_source_vultr_inference.go
+++ b/vultr/data_source_vultr_inference.go
@@ -25,11 +25,6 @@ func dataSourceVultrInference() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"usage": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     schema.TypeInt,
-			},
 		},
 	}
 }
@@ -85,25 +80,5 @@ func dataSourceVultrInferenceRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("unable to set inference `api_key` read value: %v", err)
 	}
 
-	// Grab usage
-	usage, _, err := client.Inference.GetUsage(ctx, d.Id())
-	if err == nil {
-		if err := d.Set("usage", flattenInferenceUsage(usage)); err != nil {
-			return diag.Errorf("unable to set inference `usage` read value: %v", err)
-		}
-	}
-
 	return nil
-}
-
-func flattenInferenceUsage(u *govultr.InferenceUsage) map[string]interface{} {
-	f := map[string]interface{}{
-		"chat_current_tokens":     u.Chat.CurrentTokens,
-		"chat_monthly_allotment":  u.Chat.MonthlyAllotment,
-		"chat_overage":            u.Chat.Overage,
-		"audio_tts_characters":    u.Audio.TTSCharacters,
-		"audio_tts_sm_characters": u.Audio.TTSSMCharacters,
-	}
-
-	return f
 }

--- a/vultr/resource_vultr_inference.go
+++ b/vultr/resource_vultr_inference.go
@@ -35,11 +35,6 @@ func resourceVultrInference() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"usage": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     schema.TypeInt,
-			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(defaultTimeout),
@@ -89,14 +84,6 @@ func resourceVultrInferenceRead(ctx context.Context, d *schema.ResourceData, met
 
 	if err := d.Set("api_key", inferenceSub.APIKey); err != nil {
 		return diag.Errorf("unable to set resource inference `api_key` read value: %v", err)
-	}
-
-	// Grab usage
-	usage, _, err := client.Inference.GetUsage(ctx, d.Id())
-	if err == nil {
-		if err := d.Set("usage", flattenInferenceUsage(usage)); err != nil {
-			return diag.Errorf("unable to set resource inference `usage` read value: %v", err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Update govultr from v3.30.0 to v3.31.1. Removes deprecated fields and adds `vendor` directory to .gitignore.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
