### PR TITLE
Remove old fields from org role docs

### DIFF
--- a/website/docs/r/organization_role.html.markdown
+++ b/website/docs/r/organization_role.html.markdown
@@ -20,8 +20,6 @@ resource "vultr_organization_role" "my_role" {
   description = "my role from terraform"
   type = "assumable"
   max_session_duration = 3600
-  policies = [ "bf8587f2-72e6-43e5-9ebc-dd6267eb7f4c", "5db2b8d6-ca62-415a-9f87-d2f89eff8dba" ]
-  groups = [ "2b72adbd-3f25-4ec8-b067-307a8fa4d8fa" ]
 }
 ```
 
@@ -33,8 +31,6 @@ The following arguments are supported:
 * `description` - (Required) A description of the organization role.
 * `type` - (Required) A type for the organization role.
 * `max_session_duration` - (Required) The max session length for the organization role.
-* `policies` - (Optional) A list of policy UUIDs which should be attached to the role.
-* `groups` - (Optional) A list of group UUIDs which should be attached to the role.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Remove the now read-only docs from the organization role resource documentation

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
