### PR TITLE
Hydrate instance user_data during read

### DIFF
--- a/vultr/resource_vultr_instance.go
+++ b/vultr/resource_vultr_instance.go
@@ -120,10 +120,11 @@ Will not do anything unless enable_ipv6 is also true.`,
 				Optional: true,
 			},
 			"user_data": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: canonicalizeUserDataLineEndings,
 			},
 			"activation_email": {
 				Type:     schema.TypeBool,
@@ -597,6 +598,25 @@ func resourceVultrInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	if err := d.Set("user_scheme", instance.UserScheme); err != nil {
 		return diag.Errorf("unable to set resource instance `user_scheme` read value: %v", err)
+	}
+
+	userData, _, err := client.Instance.GetUserData(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("error getting instance (%s) user_data: %v", d.Id(), err)
+	}
+
+	encodedUserData := ""
+	if userData != nil {
+		encodedUserData = userData.Data
+	}
+
+	decodedUserData, err := base64.StdEncoding.DecodeString(encodedUserData)
+	if err != nil {
+		return diag.Errorf("error decoding instance (%s) user_data: %v", d.Id(), err)
+	}
+
+	if err := d.Set("user_data", canonicalizeUserDataLineEndings(string(decodedUserData))); err != nil {
+		return diag.Errorf("unable to set resource instance `user_data` read value: %v", err)
 	}
 
 	backup, _, err := client.Instance.GetBackupSchedule(ctx, d.Id())

--- a/vultr/utility.go
+++ b/vultr/utility.go
@@ -99,3 +99,9 @@ func canonicalizeIP(val interface{}) string {
 	}
 	return ip.String()
 }
+
+func canonicalizeUserDataLineEndings(val interface{}) string {
+	raw := val.(string)
+	normalized := strings.ReplaceAll(raw, "\r\n", "\n")
+	return strings.ReplaceAll(normalized, "\r", "\n")
+}

--- a/vultr/utility_test.go
+++ b/vultr/utility_test.go
@@ -127,3 +127,42 @@ func TestCanonicalizeIP(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalizeUserDataLineEndings(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "lf unchanged",
+			in:   "#cloud-config\nmanage_etc_hosts: false\n",
+			want: "#cloud-config\nmanage_etc_hosts: false\n",
+		},
+		{
+			name: "crlf normalized",
+			in:   "#cloud-config\r\nmanage_etc_hosts: false\r\n",
+			want: "#cloud-config\nmanage_etc_hosts: false\n",
+		},
+		{
+			name: "cr normalized",
+			in:   "#cloud-config\rmanage_etc_hosts: false\r",
+			want: "#cloud-config\nmanage_etc_hosts: false\n",
+		},
+		{
+			name: "content preserved",
+			in:   "#cloud-config\nusers:\n  - name: terraform\n",
+			want: "#cloud-config\nusers:\n  - name: terraform\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := canonicalizeUserDataLineEndings(tc.in)
+			if got != tc.want {
+				t.Errorf("canonicalizeUserDataLineEndings(%q) = %q, want %q",
+					tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fetch instance user_data in the vultr_instance read path, decode the API's base64 response, and store the decoded value back into Terraform state. This lets refresh/import reconstruct create-time user_data instead of leaving the field absent and causing a spurious ForceNew diff.

Normalize CRLF/CR line endings to LF through the schema StateFunc and read path so API-returned cloud-init data compares consistently with Terraform config while preserving actual content changes.

Draft PR: this needs additional validation against real Vultr instances, especially imported instances with existing user_data, before it is treated as production-ready.

## Related Issues

Related but not fixed by this issue: https://github.com/vultr/terraform-provider-vultr/issues/477

### Checklist:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ X] Have you linted your code locally prior to submission?
* [ X] Have you successfully ran tests with your changes locally?
