### PR TITLE
Revert "Ignore node count when autoscaler is enabled (#711)"

### DIFF
--- a/vultr/resource_vultr_kubernetes.go
+++ b/vultr/resource_vultr_kubernetes.go
@@ -337,12 +337,8 @@ func resourceVultrKubernetesUpdate(ctx context.Context, d *schema.ResourceData, 
 		oldNodePoolData := oldNodePool.(map[string]interface{})
 		newNodePoolData := newNodePool.(map[string]interface{})
 
-		req := &govultr.NodePoolReqUpdate{}
-
-		// Only send node_quantity when auto_scaler is disabled
-		// When auto_scaler is enabled, the cluster autoscaler manages node count
-		if !newNodePoolData["auto_scaler"].(bool) {
-			req.NodeQuantity = newNodePoolData["node_quantity"].(int)
+		req := &govultr.NodePoolReqUpdate{
+			NodeQuantity: newNodePoolData["node_quantity"].(int),
 		}
 
 		if newNodePoolData["auto_scaler"] != oldNodePoolData["auto_scaler"] {

--- a/vultr/resource_vultr_kubernetes_nodepools.go
+++ b/vultr/resource_vultr_kubernetes_nodepools.go
@@ -314,13 +314,8 @@ func resourceVultrKubernetesNodePoolsUpdate(ctx context.Context, d *schema.Resou
 	clusterID := d.Get("cluster_id").(string)
 
 	req := &govultr.NodePoolReqUpdate{
-		Tag: govultr.StringToStringPtr(d.Get("tag").(string)),
-	}
-
-	// Only send node_quantity when auto_scaler is disabled
-	// When auto_scaler is enabled, the cluster autoscaler manages node count
-	if !d.Get("auto_scaler").(bool) {
-		req.NodeQuantity = d.Get("node_quantity").(int)
+		NodeQuantity: d.Get("node_quantity").(int),
+		Tag:          govultr.StringToStringPtr(d.Get("tag").(string)),
 	}
 
 	if d.HasChange("auto_scaler") {

--- a/vultr/vke.go
+++ b/vultr/vke.go
@@ -236,13 +236,6 @@ func resourceVultrKubernetesNodePoolsV0(isNodePool bool) *schema.Resource {
 				Type:         schema.TypeInt,
 				ValidateFunc: validation.IntAtLeast(1),
 				Required:     true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// When auto_scaler is enabled, node count is managed by cluster autoscaler
-					if autoScaler, ok := d.GetOk("auto_scaler"); ok && autoScaler.(bool) {
-						return true
-					}
-					return false
-				},
 			},
 			"auto_scaler": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
This reverts commit f67e276a8bdf7378d4c535c3ed614fd0d077a1f2.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Suppressing the diff is causing various knock-on effects such as not being able to update node quantity.  This needs a different solution with the current VKE schema versioning, or can be re-implemented when the schema is fixed so that the auto scaler fields are available to the diffsupressfunc


### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
